### PR TITLE
Prevent modifying the file system when -r is used

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -264,25 +264,15 @@ static int copy_file(int (*copy_fn)(const struct mtd_ctx *mtd,
 	struct mtd_ctx *mtd;
 	int ret;
 
-	ret = mtd_mount(opts->device_path, &mtd);
+	ret = mtd_mount(opts, &mtd);
 	if (ret < 0) {
 		log_error(ret, "unable to mount MTD");
 		return ret;
 	}
 
-	/*
-	 * Perform the requested action.  Note that an error here causes an
-	 * early return.  While calling mtd_unmount() also in case of an error
-	 * would allow all resources to be released, unmounting a YAFFS
-	 * filesystem may cause the MTD device to be written to, which is
-	 * arguably prudent to avoid after failing to read a file from an
-	 * existing filesystem (to prevent further damage to a potentially
-	 * broken filesystem).
-	 */
 	ret = copy_fn(mtd, opts);
 	if (ret < 0) {
 		log_error(ret, "copying failed");
-		return ret;
 	}
 
 	return mtd_unmount(&mtd);

--- a/src/mtd.h
+++ b/src/mtd.h
@@ -6,9 +6,11 @@
 
 #include <unistd.h>
 
+#include "options.h"
+
 struct mtd_ctx;
 
-int mtd_mount(const char *device_path, struct mtd_ctx **ctxp);
+int mtd_mount(const struct opts *opts, struct mtd_ctx **ctxp);
 int mtd_unmount(struct mtd_ctx **ctxp);
 
 int mtd_file_open_read(const struct mtd_ctx *ctx, const char *path, int *fd);


### PR DESCRIPTION
When Yaffs code detects problems (e.g. ECC errors) while mounting an MTD partition, it may attempt to rectify them by altering the data stored on the MTD.  This operation may break valid Yaffs file systems (e.g. due to OOB layout differences).  While writing a file to an MTD is inherently risky as it requires modifying the file system, reading a file from an MTD should not be considered a dangerous operation.  Meanwhile, `init_mtd_context()` always opens the MTD character device in read-write mode, so the file system may be modified even when `-r` is used.  That should not be the case as it breaks user expectations.

Fix by opening the character device in read-only mode when `-r` is used.
