### PR TITLE
Return a non-zero exit code when copying fails

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -275,7 +275,9 @@ static int copy_file(int (*copy_fn)(const struct mtd_ctx *mtd,
 		log_error(ret, "copying failed");
 	}
 
-	return mtd_unmount(&mtd);
+	mtd_unmount(&mtd);
+
+	return ret;
 }
 
 /*

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -509,7 +509,7 @@ int mtd_mount(const struct opts *opts, struct mtd_ctx **ctxp) {
 /*
  * Unmount the MTD used and release all resources associated with it.
  */
-int mtd_unmount(struct mtd_ctx **ctxp) {
+void mtd_unmount(struct mtd_ctx **ctxp) {
 	struct mtd_ctx *ctx = *ctxp;
 	int ret;
 
@@ -522,8 +522,6 @@ int mtd_unmount(struct mtd_ctx **ctxp) {
 	}
 
 	destroy_mtd_context(ctxp);
-
-	return ret;
 }
 
 /*

--- a/src/mtd.h
+++ b/src/mtd.h
@@ -11,7 +11,7 @@
 struct mtd_ctx;
 
 int mtd_mount(const struct opts *opts, struct mtd_ctx **ctxp);
-int mtd_unmount(struct mtd_ctx **ctxp);
+void mtd_unmount(struct mtd_ctx **ctxp);
 
 int mtd_file_open_read(const struct mtd_ctx *ctx, const char *path, int *fd);
 int mtd_file_open_write(const struct mtd_ctx *ctx, const char *path, int *fd);


### PR DESCRIPTION
Even when the requested copy operation fails, the copy_file() function returns the value returned by the mtd_unmount() function, which is almost guaranteed to succeed.  Since the value returned by the copy_file() function is carried over to the program's exit code, this logic results in returning an exit code indicating success even when the program fails to correctly carry out the requested copy operation.

Tweak the copy_file() function so that it returns a non-zero value when the requested copy operation fails.  Change the return type of the mtd_unmount() function to void as there is pretty much nothing that can be done to fix any potential problems it reports (log messages will still be generated in case of problems).