### PR TITLE
Handle short writes

### DIFF
--- a/src/mtd.c
+++ b/src/mtd.c
@@ -620,7 +620,7 @@ ssize_t mtd_file_read(const struct mtd_ctx *ctx, int fd, unsigned char *buf,
 	int ret;
 
 	ret = yaffs_read(fd, buf, count);
-	mtd_debug(ctx, "yaffs_read, fd=%d, ret=%d", fd, ret);
+	mtd_debug(ctx, "yaffs_read, fd=%d, count=%d, ret=%d", fd, count, ret);
 
 	if (ret < 0) {
 		ret = yaffsfs_GetLastError();
@@ -639,7 +639,7 @@ ssize_t mtd_file_write(const struct mtd_ctx *ctx, int fd,
 	int ret;
 
 	ret = yaffs_write(fd, buf, count);
-	mtd_debug(ctx, "yaffs_write, fd=%d, ret=%d", fd, ret);
+	mtd_debug(ctx, "yaffs_write, fd=%d, count=%d, ret=%d", fd, count, ret);
 
 	if (ret < 0) {
 		ret = yaffsfs_GetLastError();


### PR DESCRIPTION
The copy_from_mtd_to_file() and copy_from_file_to_mtd() functions only check for negative return values when calling data-writing functions (write() and mtd_file_write(), respectively).  This is a bug that leads to short writes causing parts of the input file to be missing from the output file without any error being indicated.  Fix by retrying writes in a loop until all the bytes read from the input file in a given loop iteration are written to the output file.