### PR TITLE
Fix reporting bad blocks to Yaffs code

### DIFF
--- a/src/mtd.c
+++ b/src/mtd.c
@@ -139,11 +139,7 @@ static int mtd_check_bad(struct yaffs_dev *dev, int block_no) {
 	mtd_debug(ctx, "ioctl=MEMGETBADBLOCK, block=%d, ret=%d, err=%d (%s)",
 		  block_no, ret, err, util_get_error(err));
 
-	if (ret < 0) {
-		return YAFFS_FAIL;
-	}
-
-	return YAFFS_OK;
+	return (ret == 0 ? YAFFS_OK : YAFFS_FAIL);
 }
 
 /*


### PR DESCRIPTION
mtd_check_bad(), the function called by Yaffs code the check whether a given MTD block is bad, only returns YAFFS_FAIL (which indicates a bad block) when the MEMGETBADBLOCK ioctl returns a negative value, i.e. when an error occurs while the kernel processes the ioctl.  Meanwhile, the MEMGETBADBLOCK ioctl returns 0 when a given block is good and 1 when a given block is bad.  Consequently, mtd_check_bad() incorrectly reports bad blocks as good, confusing Yaffs code.

Fix by making the mtd_check_bad() function only return YAFFS_OK when a given block is good and YAFFS_FAIL in any other case (bad block or error during ioctl processing).