### PR TITLE
Inband tags autodetection

### DIFF
--- a/src/mtd.c
+++ b/src/mtd.c
@@ -418,8 +418,8 @@ static int init_yaffs_dev(struct mtd_ctx *ctx, unsigned int oobavail) {
 	int is_yaffs2;
 
 	mtd_debug(ctx,
-		  "type=%02x, flags=%08x, size=%08x, erasesize=%08x, "
-		  "writesize=%08x, oobsize=%08x, oobavail=%08x",
+		  "type=%d, flags=0x%08x, size=%d, erasesize=%d, writesize=%d, "
+		  "oobsize=%d, oobavail=%d",
 		  mtd->type, mtd->flags, mtd->size, mtd->erasesize,
 		  mtd->writesize, mtd->oobsize, oobavail);
 

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -447,6 +447,17 @@ static int init_yaffs_dev(struct mtd_ctx *ctx, unsigned int oobavail) {
 		.driver_context = ctx,
 	};
 
+	mtd_debug(ctx,
+		  "yaffs_dev: total_bytes_per_chunk=%d, "
+		  "chunks_per_block=%d, spare_bytes_per_chunk=%d, "
+		  "end_block=%d, is_yaffs2=%d, inband_tags=%d",
+		  ctx->yaffs_dev->param.total_bytes_per_chunk,
+		  ctx->yaffs_dev->param.chunks_per_block,
+		  ctx->yaffs_dev->param.spare_bytes_per_chunk,
+		  ctx->yaffs_dev->param.end_block,
+		  ctx->yaffs_dev->param.is_yaffs2,
+		  ctx->yaffs_dev->param.inband_tags);
+
 	yaffs_add_device(ctx->yaffs_dev);
 
 	return 0;

--- a/src/options.c
+++ b/src/options.c
@@ -8,38 +8,7 @@
 
 #include "log.h"
 #include "options.h"
-
-/*
- * Convert the provided 'string' to an unsigned integer value according to the
- * given 'base', storing the result in 'result'.  The number represented by
- * 'string' is expected to be non-negative and not greater than UINT_MAX, in
- * which case this function returns 0; otherwise, it returns -1, which
- * indicates an error.
- */
-static int parse_number(const char *string, int base, unsigned int *result) {
-	char *first_bad_char = NULL;
-	long long ret;
-
-	if (!string) {
-		return -1;
-	}
-
-	ret = strtoll(string, &first_bad_char, base);
-	if (first_bad_char && *first_bad_char != '\0') {
-		log("unable to parse '%s' as a number (base %d)", string, base);
-		return -1;
-	}
-
-	if (ret < 0 || ret > UINT_MAX) {
-		log("number '%s' (base %d) is out of range (0 <= number <= %u)",
-		    string, base, UINT_MAX);
-		return -1;
-	}
-
-	*result = ret;
-
-	return 0;
-}
+#include "util.h"
 
 /*
  * Parse the YAFFS_TRACE_MASK environment variable and use its value to set up
@@ -53,7 +22,7 @@ void options_parse_env(void) {
 		return;
 	}
 
-	if (parse_number(env_yaffs_trace_mask, 16, &mask) < 0) {
+	if (util_parse_number(env_yaffs_trace_mask, 16, &mask) < 0) {
 		log("Invalid Yaffs trace mask '%s'", env_yaffs_trace_mask);
 		return;
 	}
@@ -98,7 +67,7 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 			{
 				unsigned int mode;
 
-				if (parse_number(optarg, 8, &mode) < 0
+				if (util_parse_number(optarg, 8, &mode) < 0
 				    || mode > INT_MAX) {
 					return -1;
 				}

--- a/src/util.c
+++ b/src/util.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -28,4 +29,36 @@ int util_get_errno_location(const char *file, int line, const char *func) {
  */
 char *util_get_error(int err) {
 	return strerror(-err);
+}
+
+/*
+ * Convert the provided 'string' to an unsigned integer value according to the
+ * given 'base', storing the result in 'result'.  The number represented by
+ * 'string' is expected to be non-negative and not greater than UINT_MAX, in
+ * which case this function returns 0; otherwise, it returns -1, which
+ * indicates an error.
+ */
+int util_parse_number(const char *string, int base, unsigned int *result) {
+	char *first_bad_char = NULL;
+	long long ret;
+
+	if (!string) {
+		return -1;
+	}
+
+	ret = strtoll(string, &first_bad_char, base);
+	if (first_bad_char && *first_bad_char != '\0') {
+		log("unable to parse '%s' as a number (base %d)", string, base);
+		return -1;
+	}
+
+	if (ret < 0 || ret > UINT_MAX) {
+		log("number '%s' (base %d) is out of range (0 <= number <= %u)",
+		    string, base, UINT_MAX);
+		return -1;
+	}
+
+	*result = ret;
+
+	return 0;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -27,3 +27,4 @@ int util_get_errno_location(const char *file, int line, const char *func);
 #endif /* __clang_analyzer__ */
 
 char *util_get_error(int err);
+int util_parse_number(const char *string, int base, unsigned int *result);


### PR DESCRIPTION
If the MTD provided has less bytes available in its OOB area than are necessary to store a full Yaffs2 tag structure (including tags ECC data) and Yaffs2 is used, enable inband tags.  This makes Yaffs2 code expect tags to be present in the flash data area, alongside the data, rather than in the OOB area.
