### PR TITLE
Handle inband tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ systems.  Yafut assumes that MTD devices with 512-byte pages use Yaffs1
 while those with 2048-byte pages use Yaffs2.  There is currently no way
 to override this assumption other than by modifying the source code.
 
+### Do I need to manually set any Yaffs parameters?
+
+Yafut tries to make reasonable assumptions about most Yaffs parameters
+to use for a given MTD, so that its use remains as simple as possible.
+However, not all Yaffs parameters can be discovered deterministically,
+in which case the educated guess attempted by Yafut may turn out to be
+wrong and specific values for certain Yaffs options will need to be
+forced by the user via command-line options.
+
+The only parameter whose autodetected value can currently be overridden
+is the use of inband tags.  Yafut assumes that inband tags are only
+necessary if the MTD does not have enough available bytes in the OOB
+area to store a full Yaffs2 tag structure (including tags ECC data).
+However, some file systems may use inband tags despite being stored on
+an MTD that does have enough available space in the OOB area to fit a
+full Yaffs2 tag structure.  For such file systems, the `-T` command-line
+option can be used to force use of inband tags.
+
 ### Does this tool really only work with Linux kernel 6.1+?
 
 Linux kernel version 6.1 is the first one that implements all the MTD

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -112,6 +113,67 @@ static void mtd_debug_hexdump_location(const char *file, int line,
 
 	mtd_debug_location(file, line, func, ctx, "%s:\n%s%s", description, hex,
 			   buf_len > 32 ? "    ..." : "");
+}
+
+/*
+ * Read the raw contents of the sysfs attribute at the provided 'sysfs_path'
+ * into 'buf', which is 'buf_len' bytes large.  The given sysfs attribute is
+ * expected to contain no more than 'buf_len' bytes of data.
+ */
+static int read_sysfs_attribute(const char *sysfs_path, char *buf,
+				size_t buf_len) {
+	int ret;
+	int fd;
+
+	fd = open(sysfs_path, O_RDONLY);
+	if (fd < 0) {
+		ret = util_get_errno();
+		log_error(ret, "unable to open %s", sysfs_path);
+		return ret;
+	}
+
+	ret = read(fd, buf, buf_len);
+	if (ret < 0) {
+		ret = util_get_errno();
+		log_error(ret, "error reading %s", sysfs_path);
+	}
+
+	close(fd);
+
+	return ret;
+}
+
+/*
+ * Store the value reported by /sys/class/mtd/mtd<X>/oobavail (derived from
+ * 'mtd_path') in 'oobavail'.  That value is necessary for determining whether
+ * use of inband tags is required and it is not returned by the MEMGETINFO
+ * ioctl, so it has to be retrieved in a different way than the other MTD
+ * parameters.
+ */
+static int read_oobavail_from_sysfs(const char *mtd_path,
+				    unsigned int *oobavail) {
+	char oobavail_str[16] = {0};
+	char path[32];
+	char *newline;
+	int ret;
+
+	ret = snprintf(path, sizeof(path), "/sys/class/mtd/%s/oobavail",
+		       basename(mtd_path));
+	if (ret < 0 || (unsigned int)ret >= sizeof(path)) {
+		return -ENOMEM;
+	}
+
+	ret = read_sysfs_attribute(path, oobavail_str, sizeof(oobavail_str));
+	if (ret < 0) {
+		return ret;
+	}
+
+	newline = strrchr(oobavail_str, '\n');
+	if (newline) {
+		*newline = '\0';
+	}
+
+	return util_parse_number(oobavail_str, 10, oobavail);
 }
 
 /*
@@ -349,14 +411,14 @@ static const struct yaffs_driver yaffs_driver_mtd = {
 /*
  * Initialize the structure used by Yaffs code to interact with the given MTD.
  */
-static int init_yaffs_dev(struct mtd_ctx *ctx) {
+static int init_yaffs_dev(struct mtd_ctx *ctx, unsigned int oobavail) {
 	const struct mtd_info_user *mtd = &ctx->mtd;
 
 	mtd_debug(ctx,
 		  "type=%02x, flags=%08x, size=%08x, erasesize=%08x, "
-		  "writesize=%08x, oobsize=%08x",
+		  "writesize=%08x, oobsize=%08x, oobavail=%08x",
 		  mtd->type, mtd->flags, mtd->size, mtd->erasesize,
-		  mtd->writesize, mtd->oobsize);
+		  mtd->writesize, mtd->oobsize, oobavail);
 
 	ctx->yaffs_dev = calloc(1, sizeof(*ctx->yaffs_dev));
 	if (!ctx->yaffs_dev) {
@@ -388,6 +450,7 @@ static int init_yaffs_dev(struct mtd_ctx *ctx) {
  * yaffs_dev.  Then initialize Yaffs code for the MTD in question.
  */
 static int init_mtd_context(const struct opts *opts, struct mtd_ctx **ctxp) {
+	unsigned int oobavail;
 	struct mtd_ctx *ctx;
 	int flags;
 	int ret;
@@ -414,7 +477,13 @@ static int init_mtd_context(const struct opts *opts, struct mtd_ctx **ctxp) {
 		goto err_close_mtd_fd;
 	}
 
-	ret = init_yaffs_dev(ctx);
+	ret = read_oobavail_from_sysfs(ctx->mtd_path, &oobavail);
+	if (ret < 0) {
+		log_error(ret, "unable to get count of available OOB bytes");
+		goto err_close_mtd_fd;
+	}
+
+	ret = init_yaffs_dev(ctx, oobavail);
 	if (ret < 0) {
 		log_error(ret, "unable to initialize Yaffs device");
 		goto err_close_mtd_fd;

--- a/src/options.c
+++ b/src/options.c
@@ -8,38 +8,7 @@
 
 #include "log.h"
 #include "options.h"
-
-/*
- * Convert the provided 'string' to an unsigned integer value according to the
- * given 'base', storing the result in 'result'.  The number represented by
- * 'string' is expected to be non-negative and not greater than UINT_MAX, in
- * which case this function returns 0; otherwise, it returns -1, which
- * indicates an error.
- */
-static int parse_number(const char *string, int base, unsigned int *result) {
-	char *first_bad_char = NULL;
-	long long ret;
-
-	if (!string) {
-		return -1;
-	}
-
-	ret = strtoll(string, &first_bad_char, base);
-	if (first_bad_char && *first_bad_char != '\0') {
-		log("unable to parse '%s' as a number (base %d)", string, base);
-		return -1;
-	}
-
-	if (ret < 0 || ret > UINT_MAX) {
-		log("number '%s' (base %d) is out of range (0 <= number <= %u)",
-		    string, base, UINT_MAX);
-		return -1;
-	}
-
-	*result = ret;
-
-	return 0;
-}
+#include "util.h"
 
 /*
  * Parse the YAFFS_TRACE_MASK environment variable and use its value to set up
@@ -53,7 +22,7 @@ void options_parse_env(void) {
 		return;
 	}
 
-	if (parse_number(env_yaffs_trace_mask, 16, &mask) < 0) {
+	if (util_parse_number(env_yaffs_trace_mask, 16, &mask) < 0) {
 		log("Invalid Yaffs trace mask '%s'", env_yaffs_trace_mask);
 		return;
 	}
@@ -98,7 +67,7 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 			{
 				unsigned int mode;
 
-				if (parse_number(optarg, 8, &mode) < 0
+				if (util_parse_number(optarg, 8, &mode) < 0
 				    || mode > INT_MAX) {
 					return -1;
 				}

--- a/src/options.c
+++ b/src/options.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <limits.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -43,7 +44,7 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 		.dst_mode = FILE_MODE_UNSPECIFIED,
 	};
 
-	while ((opt = getopt(argc, argv, "d:hi:m:o:rvw")) != -1) {
+	while ((opt = getopt(argc, argv, "d:hi:m:o:rTvw")) != -1) {
 		switch (opt) {
 		case 'd':
 			if (opts->device_path) {
@@ -88,6 +89,13 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 				return -1;
 			}
 			opts->mode = PROGRAM_MODE_READ;
+			break;
+		case 'T':
+			if (opts->force_inband_tags) {
+				log("-T can only be used once");
+				return -1;
+			}
+			opts->force_inband_tags = true;
 			break;
 		case 'v':
 			if (log_level >= 2) {

--- a/src/options.h
+++ b/src/options.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #define USAGE_MSG                                                              \
 	"Usage: %s "                                                           \
 	"-d /dev/mtdX "                                                        \
@@ -11,6 +13,7 @@
 	"-i <src> "                                                            \
 	"-o <dst> "                                                            \
 	"[ -m <mode> ] "                                                       \
+	"[ -T ] "                                                              \
 	"[ -v ] "                                                              \
 	"[ -h ] "                                                              \
 	"\n\n"                                                                 \
@@ -21,6 +24,7 @@
 	"    -o  path to the destination file (use '-' to write to stdout)\n"  \
 	"    -m  set destination file access permissions to <mode> (octal)\n"  \
 	"        (default: copy access permissions from <src>)\n"              \
+	"    -T  force inband tags\n"                                          \
 	"    -v  verbose output (can be used up to two times)\n"               \
 	"    -h  show usage information and exit\n"
 
@@ -38,6 +42,7 @@ struct opts {
 	const char *src_path;
 	const char *dst_path;
 	int dst_mode;
+	bool force_inband_tags;
 };
 
 void options_parse_env(void);

--- a/src/util.c
+++ b/src/util.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -28,4 +29,36 @@ int util_get_errno_location(const char *file, int line, const char *func) {
  */
 char *util_get_error(int err) {
 	return strerror(-err);
+}
+
+/*
+ * Convert the provided 'string' to an unsigned integer value according to the
+ * given 'base', storing the result in 'result'.  The number represented by
+ * 'string' is expected to be non-negative and not greater than UINT_MAX, in
+ * which case this function returns 0; otherwise, it returns -1, which
+ * indicates an error.
+ */
+int util_parse_number(const char *string, int base, unsigned int *result) {
+	char *first_bad_char = NULL;
+	long long ret;
+
+	if (!string) {
+		return -1;
+	}
+
+	ret = strtoll(string, &first_bad_char, base);
+	if (first_bad_char && *first_bad_char != '\0') {
+		log("unable to parse '%s' as a number (base %d)", string, base);
+		return -1;
+	}
+
+	if (ret < 0 || ret > UINT_MAX) {
+		log("number '%s' (base %d) is out of range (0 <= number <= %u)",
+		    string, base, UINT_MAX);
+		return -1;
+	}
+
+	*result = ret;
+
+	return 0;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -27,3 +27,4 @@ int util_get_errno_location(const char *file, int line, const char *func);
 #endif /* __clang_analyzer__ */
 
 char *util_get_error(int err);
+int util_parse_number(const char *string, int base, unsigned int *result);


### PR DESCRIPTION
If the MTD provided has less bytes available in its OOB area than are necessary to store a full Yaffs2 tag structure (including tags ECC data) and Yaffs2 is used, inband tags must be enabled.  This makes Yaffs2 code expect tags to be present in the flash data area, alongside the data, rather than in the OOB area.

Also add a new command-line option, -T, which allows use of inband tags to be forced.  This enables handling file systems using inband tags despite being stored on an MTD that has enough available space in the OOB area to fit a full Yaffs2 tag structure.
