### PR TITLE
Enable specifying chunk and block sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ Run `yafut -h` for further usage instructions.
 
 Yaffs code that Yafut builds upon supports both Yaffs1 and Yaffs2 file
 systems.  Yafut assumes that MTD devices with 512-byte pages use Yaffs1
-while those with 2048-byte pages use Yaffs2.  There is currently no way
-to override this assumption other than by modifying the source code.
+while those with 1024-byte or larger pages use Yaffs2.  There is
+currently no way to override this assumption other than by modifying the
+source code.
 
 ### Do I need to manually set any Yaffs parameters?
 

--- a/README.md
+++ b/README.md
@@ -82,14 +82,20 @@ in which case the educated guess attempted by Yafut may turn out to be
 wrong and specific values for certain Yaffs options will need to be
 forced by the user via command-line options.
 
-The only parameter whose autodetected value can currently be overridden
-is the use of inband tags.  Yafut assumes that inband tags are only
-necessary if the MTD does not have enough available bytes in the OOB
-area to store a full Yaffs2 tag structure (including tags ECC data).
-However, some file systems may use inband tags despite being stored on
-an MTD that does have enough available space in the OOB area to fit a
-full Yaffs2 tag structure.  For such file systems, the `-T` command-line
-option can be used to force use of inband tags.
+The Yaffs parameters that can currently be controlled using command-line
+options are:
+
+  - Chunk size (`-C`) and block size (`-B`).  Yafut uses autodetected
+    MTD parameters for these parameters by default, but they can be
+    forced to specific values if necessary.
+
+  - Use of inband tags (`-T`).  Yafut assumes that inband tags are only
+    necessary if the MTD does not have enough available bytes in the OOB
+    area to store a full Yaffs2 tag structure (including tags ECC data).
+    However, some file systems may use inband tags despite being stored
+    on an MTD that does have enough available space in the OOB area to
+    fit a full Yaffs2 tag structure.  For such file systems, the `-T`
+    command-line option can be used to force use of inband tags.
 
 ### Does this tool really only work with Linux kernel 6.1+?
 

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -204,7 +204,7 @@ static int init_yaffs_dev(struct mtd_ctx *ctx, const struct mtd_info_user *mtd,
 		return -ENOMEM;
 	}
 
-	is_yaffs2 = (chunk_size >= 2048);
+	is_yaffs2 = (chunk_size >= 1024);
 	inband_tags = (is_yaffs2
 		       && (oobavail < sizeof(struct yaffs_packed_tags2)
 			   || force_inband_tags));

--- a/src/options.c
+++ b/src/options.c
@@ -86,10 +86,32 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 	*opts = (struct opts){
 		.mode = PROGRAM_MODE_UNSPECIFIED,
 		.dst_mode = FILE_MODE_UNSPECIFIED,
+		.chunk_size = SIZE_UNSPECIFIED,
+		.block_size = SIZE_UNSPECIFIED,
 	};
 
-	while ((opt = getopt(argc, argv, "d:hi:m:o:rTvw")) != -1) {
+	while ((opt = getopt(argc, argv, "B:C:d:hi:m:o:rTvw")) != -1) {
 		switch (opt) {
+		case 'B':
+			if (opts->block_size != SIZE_UNSPECIFIED) {
+				log("-B can only be used once");
+				return -1;
+			}
+			if (parse_int(optarg, 10, true, &opts->block_size)
+			    < 0) {
+				return -1;
+			}
+			break;
+		case 'C':
+			if (opts->chunk_size != SIZE_UNSPECIFIED) {
+				log("-C can only be used once");
+				return -1;
+			}
+			if (parse_int(optarg, 10, true, &opts->chunk_size)
+			    < 0) {
+				return -1;
+			}
+			break;
 		case 'd':
 			if (opts->device_path) {
 				log("-d can only be used once");

--- a/src/options.c
+++ b/src/options.c
@@ -4,7 +4,9 @@
 
 #include <limits.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "log.h"
@@ -29,6 +31,48 @@ void options_parse_env(void) {
 	}
 
 	log_set_yaffs_trace_mask(mask);
+}
+
+/*
+ * Convert the provided 'string' to a signed integer value according to the
+ * given 'base', storing the result in 'result'.  If 'suffixes_allowed' is
+ * 'true', also handle an optional 'k' suffix (kilobytes).
+ */
+static int parse_int(const char *string, int base, bool suffixes_allowed,
+		     int *result) {
+	unsigned int multiplier = 1;
+	unsigned int value;
+	char copy[32];
+	int ret;
+
+	ret = snprintf(copy, sizeof(copy), "%s", string);
+	if (ret < 0 || (unsigned int)ret >= sizeof(copy)) {
+		log("'%s' is too long to parse as a number", string);
+		return -1;
+	}
+
+	if (suffixes_allowed) {
+		size_t len = strlen(copy);
+
+		if (copy[len - 1] == 'k') {
+			multiplier = 1024;
+			copy[len - 1] = '\0';
+		}
+	}
+
+	ret = util_parse_number(copy, base, &value);
+	if (ret < 0) {
+		return -1;
+	}
+
+	if (value > INT_MAX / multiplier) {
+		log("number '%s' is too large", string);
+		return -1;
+	}
+
+	*result = value * multiplier;
+
+	return 0;
 }
 
 /*
@@ -65,15 +109,8 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 				log("-m can only be used once");
 				return -1;
 			}
-			{
-				unsigned int mode;
-
-				if (util_parse_number(optarg, 8, &mode) < 0
-				    || mode > INT_MAX) {
-					return -1;
-				}
-
-				opts->dst_mode = mode;
+			if (parse_int(optarg, 8, false, &opts->dst_mode) < 0) {
+				return -1;
 			}
 			break;
 		case 'o':

--- a/src/options.h
+++ b/src/options.h
@@ -13,6 +13,8 @@
 	"-i <src> "                                                            \
 	"-o <dst> "                                                            \
 	"[ -m <mode> ] "                                                       \
+	"[ -C <bytes> ] "                                                      \
+	"[ -B <bytes> ] "                                                      \
 	"[ -T ] "                                                              \
 	"[ -v ] "                                                              \
 	"[ -h ] "                                                              \
@@ -24,6 +26,8 @@
 	"    -o  path to the destination file (use '-' to write to stdout)\n"  \
 	"    -m  set destination file access permissions to <mode> (octal)\n"  \
 	"        (default: copy access permissions from <src>)\n"              \
+	"    -C  force Yaffs chunk size to <bytes> (use 'k' suffix for KiB)\n" \
+	"    -B  force Yaffs block size to <bytes> (use 'k' suffix for KiB)\n" \
 	"    -T  force inband tags\n"                                          \
 	"    -v  verbose output (can be used up to two times)\n"               \
 	"    -h  show usage information and exit\n"
@@ -35,6 +39,7 @@ enum program_mode {
 };
 
 #define FILE_MODE_UNSPECIFIED -1
+#define SIZE_UNSPECIFIED -1
 
 struct opts {
 	enum program_mode mode;
@@ -42,6 +47,8 @@ struct opts {
 	const char *src_path;
 	const char *dst_path;
 	int dst_mode;
+	int chunk_size;
+	int block_size;
 	bool force_inband_tags;
 };
 


### PR DESCRIPTION
Add two new command-line options, -C and -B, which allow, respectively, to force a specific chunk size and a specific block size that Yaffs code should use.  This will be particularly useful for NOR flash, which is byte-addressable and therefore the Yaffs layout used is more arbitrary than on NAND flash, where it is limited by hardware geometry.
