### PR TITLE
Data offset improvements

### DIFF
--- a/src/ydrv.c
+++ b/src/ydrv.c
@@ -106,7 +106,7 @@ static void ydrv_debug_hexdump_location(const char *file, int line,
  */
 static int ydrv_check_bad(struct yaffs_dev *dev, int block_no) {
 	const struct ydrv_ctx *ctx = dev->driver_context;
-	off_t offset = block_no * ctx->block_size;
+	long long offset = block_no * ctx->block_size;
 	int err = 0;
 	int ret;
 
@@ -133,7 +133,7 @@ static int ydrv_check_bad(struct yaffs_dev *dev, int block_no) {
  */
 static int ydrv_erase_block(struct yaffs_dev *dev, int block_no) {
 	const struct ydrv_ctx *ctx = dev->driver_context;
-	off_t offset = block_no * ctx->block_size;
+	long long offset = block_no * ctx->block_size;
 	int err = 0;
 	int ret;
 
@@ -169,7 +169,7 @@ static int ydrv_erase_block(struct yaffs_dev *dev, int block_no) {
  */
 static int ydrv_mark_bad(struct yaffs_dev *dev, int block_no) {
 	const struct ydrv_ctx *ctx = dev->driver_context;
-	off_t offset = block_no * ctx->block_size;
+	long long offset = block_no * ctx->block_size;
 	int err = 0;
 	int ret;
 
@@ -224,7 +224,7 @@ static int ydrv_read_chunk(struct yaffs_dev *dev, int nand_chunk, u8 *data,
 			   int data_len, u8 *oob, int oob_len,
 			   enum yaffs_ecc_result *ecc_result_out) {
 	const struct ydrv_ctx *ctx = dev->driver_context;
-	off_t offset = nand_chunk * ctx->chunk_size;
+	long long offset = nand_chunk * ctx->chunk_size;
 	enum yaffs_ecc_result ecc_result;
 	int err = 0;
 	int ret;
@@ -275,7 +275,7 @@ static int ydrv_write_chunk(struct yaffs_dev *dev, int nand_chunk,
 			    const u8 *data, int data_len, const u8 *oob,
 			    int oob_len) {
 	const struct ydrv_ctx *ctx = dev->driver_context;
-	off_t offset = nand_chunk * ctx->chunk_size;
+	long long offset = nand_chunk * ctx->chunk_size;
 	int err = 0;
 	int ret;
 

--- a/src/ydrv.c
+++ b/src/ydrv.c
@@ -136,8 +136,9 @@ static int ydrv_check_bad(struct yaffs_dev *dev, int block_no) {
 		err = util_get_errno();
 	}
 
-	ydrv_debug("ioctl=MEMGETBADBLOCK, block=%d, ret=%d, err=%d (%s)",
-		   block_no, ret, err, util_get_error(err));
+	ydrv_debug("ioctl=MEMGETBADBLOCK, block=%d, offset=%lld (0x%08llx), "
+		   "ret=%d, err=%d (%s)",
+		   block_no, offset, offset, ret, err, util_get_error(err));
 
 	return (ret == 0 ? YAFFS_OK : YAFFS_FAIL);
 }
@@ -168,8 +169,10 @@ static int ydrv_erase_block(struct yaffs_dev *dev, int block_no) {
 		err = util_get_errno();
 	}
 
-	ydrv_debug("ioctl=MEMERASE64, block=%d, ret=%d, err=%d (%s)", block_no,
-		   ret, err, util_get_error(err));
+	ydrv_debug(
+		"ioctl=MEMERASE64, block=%d, offset=%lld (0x%08llx), ret=%d, "
+		"err=%d (%s)",
+		block_no, offset, offset, ret, err, util_get_error(err));
 
 	if (ret < 0) {
 		return YAFFS_FAIL;
@@ -199,8 +202,9 @@ static int ydrv_mark_bad(struct yaffs_dev *dev, int block_no) {
 		err = util_get_errno();
 	}
 
-	ydrv_debug("ioctl=MEMSETBADBLOCK, block=%d, ret=%d, err=%d (%s)",
-		   block_no, ret, err, util_get_error(err));
+	ydrv_debug("ioctl=MEMSETBADBLOCK, block=%d, offset=%lld (0x%08llx), "
+		   "ret=%d, err=%d (%s)",
+		   block_no, offset, offset, ret, err, util_get_error(err));
 
 	if (ret < 0) {
 		return YAFFS_FAIL;
@@ -265,11 +269,10 @@ static int ydrv_read_chunk(struct yaffs_dev *dev, int nand_chunk, u8 *data,
 		err = util_get_errno();
 	}
 
-	ydrv_debug(
-		"ioctl=MEMREAD, chunk=%d, data=%p (%d), oob=%p (%d), ret=%d, "
-		"err=%d (%s)",
-		nand_chunk, data, data_len, oob, oob_len, ret, err,
-		util_get_error(err));
+	ydrv_debug("ioctl=MEMREAD, chunk=%d, offset=%lld (0x%08llx), "
+		   "data=%p (%d), oob=%p (%d), ret=%d, err=%d (%s)",
+		   nand_chunk, offset, offset, data, data_len, oob, oob_len,
+		   ret, err, util_get_error(err));
 	ydrv_debug_hexdump(data, data_len, "data");
 	ydrv_debug_hexdump(oob, oob_len, "oob");
 
@@ -315,10 +318,10 @@ static int ydrv_write_chunk(struct yaffs_dev *dev, int nand_chunk,
 		err = util_get_errno();
 	}
 
-	ydrv_debug("ioctl=MEMWRITE, chunk=%d, data=%p (%d), oob=%p (%d), "
-		   "ret=%d, err=%d (%s)",
-		   nand_chunk, data, data_len, oob, oob_len, ret, err,
-		   util_get_error(err));
+	ydrv_debug("ioctl=MEMWRITE, chunk=%d, offset=%lld (0x%08llx), "
+		   "data=%p (%d), oob=%p (%d), ret=%d, err=%d (%s)",
+		   nand_chunk, offset, offset, data, data_len, oob, oob_len,
+		   ret, err, util_get_error(err));
 	ydrv_debug_hexdump(data, data_len, "data");
 	ydrv_debug_hexdump(oob, oob_len, "oob");
 


### PR DESCRIPTION
Implement a new helper function, ydrv_get_data_offset_for_chunk(), which calculates the MTD offset at which data starts for a specific Yaffs chunk.  While more complicated than a simple multiplication, the new function handles Yaffs layouts in which the block size is not a multiple of the chunk size (with padding between the last chunk in a block and the first chunk of the following block).  While such layouts do not really make sense for NAND flash, they can be used on NOR flash.
