### PR TITLE
Support disabling ECC for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,17 @@ options are:
 
   - Use of inband tags (`-T`).  Yafut assumes that inband tags are only
     necessary if the MTD does not have enough available bytes in the OOB
-    area to store a full Yaffs2 tag structure (including tags ECC data).
-    However, some file systems may use inband tags despite being stored
-    on an MTD that does have enough available space in the OOB area to
-    fit a full Yaffs2 tag structure.  For such file systems, the `-T`
-    command-line option can be used to force use of inband tags.
+    area to store a Yaffs2 tag structure (whether that includes ECC data
+    for tags or not depends on whether the `-E` option is used, see
+    below).  However, some file systems may use inband tags despite
+    being stored on an MTD that does have enough available space in the
+    OOB area to fit a Yaffs2 tag structure.  For such file systems, the
+    `-T` command-line option can be used to force use of inband tags.
+
+  - Use of ECC for tags (`-E`).  Yafut assumes that Yaffs2 tag
+    structures include ECC data for tags by default.  If a given file
+    system does not use ECC for tags, the `-E` command-line option can
+    be used to tell Yafut to act accordingly.
 
 ### Does this tool really only work with Linux kernel 6.1+?
 

--- a/src/options.c
+++ b/src/options.c
@@ -90,7 +90,7 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 		.block_size = SIZE_UNSPECIFIED,
 	};
 
-	while ((opt = getopt(argc, argv, "B:C:d:hi:m:o:rTvw")) != -1) {
+	while ((opt = getopt(argc, argv, "B:C:d:Ehi:m:o:rTvw")) != -1) {
 		switch (opt) {
 		case 'B':
 			if (opts->block_size != SIZE_UNSPECIFIED) {
@@ -118,6 +118,13 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 				return -1;
 			}
 			opts->device_path = optarg;
+			break;
+		case 'E':
+			if (opts->disable_ecc_for_tags) {
+				log("-E can only be used once");
+				return -1;
+			}
+			opts->disable_ecc_for_tags = true;
 			break;
 		case 'i':
 			if (opts->src_path) {

--- a/src/options.h
+++ b/src/options.h
@@ -16,6 +16,7 @@
 	"[ -C <bytes> ] "                                                      \
 	"[ -B <bytes> ] "                                                      \
 	"[ -T ] "                                                              \
+	"[ -E ] "                                                              \
 	"[ -v ] "                                                              \
 	"[ -h ] "                                                              \
 	"\n\n"                                                                 \
@@ -29,6 +30,7 @@
 	"    -C  force Yaffs chunk size to <bytes> (use 'k' suffix for KiB)\n" \
 	"    -B  force Yaffs block size to <bytes> (use 'k' suffix for KiB)\n" \
 	"    -T  force inband tags\n"                                          \
+	"    -E  disable ECC for tags\n"                                       \
 	"    -v  verbose output (can be used up to two times)\n"               \
 	"    -h  show usage information and exit\n"
 
@@ -50,6 +52,7 @@ struct opts {
 	int chunk_size;
 	int block_size;
 	bool force_inband_tags;
+	bool disable_ecc_for_tags;
 };
 
 void options_parse_env(void);


### PR DESCRIPTION
Some Yaffs2 file systems do not use ECC for tags.  Yafut needs to handle such file systems.

Add a new command-line option, -E, which allows use of ECC for tags to be disabled.  Ensure the logic used for autodetecting use of inband tags also accounts for the value of this new option.

Update README.md to explain in what scenario the new option may be useful.