### PR TITLE
Support operating on regular files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ that employs [Yaffs Direct Interface (YDI)][YDI] and Linux [Memory
 Technology Devices (MTD)][MTD] ioctls to interact with Yaffs file
 systems from userspace.  It enables copying files from/to Yaffs file
 systems even if the kernel does not have native support for the Yaffs
-file system compiled in.
+file system compiled in.  Yafut also has limited support for copying
+files from/to Yaffs file system images stored in regular files.
 
 ## Requirements
 
@@ -155,6 +156,17 @@ No.  Here is why:
     the NAND device in raw mode (i.e. without using the Linux kernel's
     autoplacement mechanism for writing to the OOB area) and the concept
     of customizing the OOB layout does not really apply for Yaffs1.
+
+### Is this tool also able to work with Yaffs image files?
+
+Yes, to an extent.  The argument passed via the `-d` command-line option
+can be a path to either an MTD character device representing NAND/NOR
+flash memory or a regular file containing a Yaffs file system image.
+However, there is currently no support for working with file system
+images that include OOB data (e.g. NAND flash dumps).  Like for NOR
+flash, the Yaffs layout used for a given file system image can be fairly
+arbitrary and therefore Yaffs parameters for such a file system will
+likely need to be provided manually (see above).
 
 ## Troubleshooting & Debugging
 

--- a/src/options.h
+++ b/src/options.h
@@ -8,7 +8,7 @@
 
 #define USAGE_MSG                                                              \
 	"Usage: %s "                                                           \
-	"-d /dev/mtdX "                                                        \
+	"-d { /dev/mtdX | /path/to/yaffs.img } "                               \
 	"{ -r | -w } "                                                         \
 	"-i <src> "                                                            \
 	"-o <dst> "                                                            \
@@ -20,7 +20,7 @@
 	"[ -v ] "                                                              \
 	"[ -h ] "                                                              \
 	"\n\n"                                                                 \
-	"    -d  path to the MTD character device to read from or write to\n"  \
+	"    -d  path to the MTD character device (or Yaffs image) to use\n"   \
 	"    -r  read a file from the MTD into a local file\n"                 \
 	"    -w  write a local file to a file on the MTD\n"                    \
 	"    -i  path to the source file (use '-' to read from stdin)\n"       \

--- a/src/ydrv.c
+++ b/src/ydrv.c
@@ -218,20 +218,12 @@ static int ydrv_erase_block(struct yaffs_dev *dev, int block_no) {
 }
 
 /*
- * Mark the given MTD block as bad.
- *
- * (This is the 'drv_mark_bad_fn' callback of struct yaffs_driver.)
+ * Mark the given MTD block as bad on NAND or NOR flash.
  */
-static int ydrv_mark_bad(struct yaffs_dev *dev, int block_no) {
-	const struct ydrv_ctx *ctx = dev->driver_context;
+static int ydrv_mark_bad_nand_or_nor(const struct ydrv_ctx *ctx, int block_no) {
 	long long offset = block_no * ctx->block_size;
 	int err = 0;
 	int ret;
-
-	if (block_no < 0) {
-		ydrv_debug("block_no=%d", block_no);
-		return YAFFS_FAIL;
-	}
 
 	ret = linux_ioctl(ctx->mtd_fd, MEMSETBADBLOCK, &offset);
 	if (ret < 0) {
@@ -247,6 +239,29 @@ static int ydrv_mark_bad(struct yaffs_dev *dev, int block_no) {
 	}
 
 	return YAFFS_OK;
+}
+
+/*
+ * Mark the given MTD block as bad.
+ *
+ * (This is the 'drv_mark_bad_fn' callback of struct yaffs_driver.)
+ */
+static int ydrv_mark_bad(struct yaffs_dev *dev, int block_no) {
+	const struct ydrv_ctx *ctx = dev->driver_context;
+
+	if (block_no < 0) {
+		ydrv_debug("block_no=%d", block_no);
+		return YAFFS_FAIL;
+	}
+
+	switch (ctx->mtd_type) {
+	case MTD_TYPE_NAND:
+	case MTD_TYPE_NOR:
+		return ydrv_mark_bad_nand_or_nor(ctx, block_no);
+	default:
+		log("unknown MTD type %d", ctx->mtd_type);
+		return YAFFS_FAIL;
+	}
 }
 
 /*

--- a/src/ydrv.h
+++ b/src/ydrv.h
@@ -7,6 +7,7 @@
 enum ydrv_mtd_type {
 	MTD_TYPE_NAND,
 	MTD_TYPE_NOR,
+	MTD_TYPE_FILE,
 };
 
 int ydrv_init(struct yaffs_dev *yaffs_dev, int mtd_fd,


### PR DESCRIPTION
Yafut is currently only able to operate on MTD character devices representing NAND or NOR flash.  This stems from the fact that it relies on various ioctls exposed by MTD character devices for carrying out the actions requested by Yaffs code.

However, Yafut reads/writes data from/to NOR flash using `pread()` and `pwrite()`, which can also be used for reading from/writing to regular files, and the remaining Yaffs driver callbacks can either be no-ops for regular files or they can be extended with non-ioctl-based counterparts of the existing callbacks.
