### PR TITLE
Support disabling Yaffs2 checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ options are:
     system does not use ECC for tags, the `-E` command-line option can
     be used to tell Yafut to act accordingly.
 
+  - Use of Yaffs2 checkpoints (`-P` to disable).  By default, Yaffs2
+    code stores a snapshot of its runtime state (called a "checkpoint")
+    in the file system when the latter gets unmounted or `sync()`'d.
+    Using these checkpoints speeds up file system mounting, but occupies
+    extra storage space.  If desired, reading and writing checkpoints
+    can be disabled using the `-P` command-line option.
+
 ### Which Yaffs file system versions does this tool work with?
 
 Yaffs code that Yafut builds upon supports both Yaffs1 and Yaffs2 file

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -387,20 +387,25 @@ static int init_yaffs_dev(struct mtd_ctx *ctx, const struct opts *opts,
 						       geometry->oobavail,
 						       opts),
 			.no_tags_ecc = opts->disable_ecc_for_tags,
+			.skip_checkpt_rd = opts->disable_checkpoints,
+			.skip_checkpt_wr = opts->disable_checkpoints,
 		},
 	};
 
 	mtd_debug(ctx,
 		  "total_bytes_per_chunk=%d, chunks_per_block=%d, "
 		  "spare_bytes_per_chunk=%d, end_block=%d, is_yaffs2=%d, "
-		  "inband_tags=%d, no_tags_ecc=%d",
+		  "inband_tags=%d, no_tags_ecc=%d, skip_checkpt_rd=%d, "
+		  "skip_checkpt_wr=%d",
 		  ctx->yaffs_dev->param.total_bytes_per_chunk,
 		  ctx->yaffs_dev->param.chunks_per_block,
 		  ctx->yaffs_dev->param.spare_bytes_per_chunk,
 		  ctx->yaffs_dev->param.end_block,
 		  ctx->yaffs_dev->param.is_yaffs2,
 		  ctx->yaffs_dev->param.inband_tags,
-		  ctx->yaffs_dev->param.no_tags_ecc);
+		  ctx->yaffs_dev->param.no_tags_ecc,
+		  ctx->yaffs_dev->param.skip_checkpt_rd,
+		  ctx->yaffs_dev->param.skip_checkpt_wr);
 
 	return 0;
 }

--- a/src/options.c
+++ b/src/options.c
@@ -90,7 +90,7 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 		.block_size = SIZE_UNSPECIFIED,
 	};
 
-	while ((opt = getopt(argc, argv, "B:C:d:Ehi:m:o:rTvw")) != -1) {
+	while ((opt = getopt(argc, argv, "B:C:d:Ehi:m:o:PrTvw")) != -1) {
 		switch (opt) {
 		case 'B':
 			if (opts->block_size != SIZE_UNSPECIFIED) {
@@ -148,6 +148,13 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 				return -1;
 			}
 			opts->dst_path = optarg;
+			break;
+		case 'P':
+			if (opts->disable_checkpoints) {
+				log("-P can only be used once");
+				return -1;
+			}
+			opts->disable_checkpoints = true;
 			break;
 		case 'r':
 			if (opts->mode != PROGRAM_MODE_UNSPECIFIED) {

--- a/src/options.h
+++ b/src/options.h
@@ -17,6 +17,7 @@
 	"[ -B <bytes> ] "                                                      \
 	"[ -T ] "                                                              \
 	"[ -E ] "                                                              \
+	"[ -P ] "                                                              \
 	"[ -v ] "                                                              \
 	"[ -h ] "                                                              \
 	"\n\n"                                                                 \
@@ -31,6 +32,7 @@
 	"    -B  force Yaffs block size to <bytes> (use 'k' suffix for KiB)\n" \
 	"    -T  force inband tags\n"                                          \
 	"    -E  disable ECC for tags\n"                                       \
+	"    -P  disable Yaffs2 checkpoints\n"                                 \
 	"    -v  verbose output (can be used up to two times)\n"               \
 	"    -h  show usage information and exit\n"
 
@@ -53,6 +55,7 @@ struct opts {
 	int block_size;
 	bool force_inband_tags;
 	bool disable_ecc_for_tags;
+	bool disable_checkpoints;
 };
 
 void options_parse_env(void);


### PR DESCRIPTION
By default, Yaffs2 code stores a snapshot of its runtime state (called a "checkpoint") in the file system when the latter gets unmounted or `sync()`'d.  Reading such a checkpoint speeds up file system mounting.

Checkpoints are merely a performance optimization and maintaining them requires extra storage space.  Add a new command-line option, `-P`, which prevents checkpoints from being read or written, saving some storage space at the cost of slower file system mounting.  Update `README.md` accordingly.