### PR TITLE
Support disabling Yaffs2 summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ options are:
     extra storage space.  If desired, reading and writing checkpoints
     can be disabled using the `-P` command-line option.
 
+  - Writing Yaffs2 summaries (`-S` to disable).  By default, Yaffs2
+    code stores a so-called summary at the end of each block.  Using
+    these summaries speeds up file system scanning, but occupies extra
+    storage space.  If desired, writing summaries can be disabled using
+    the `-S` command-line option.
+
 ### Which Yaffs file system versions does this tool work with?
 
 Yaffs code that Yafut builds upon supports both Yaffs1 and Yaffs2 file

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -389,6 +389,7 @@ static int init_yaffs_dev(struct mtd_ctx *ctx, const struct opts *opts,
 			.no_tags_ecc = opts->disable_ecc_for_tags,
 			.skip_checkpt_rd = opts->disable_checkpoints,
 			.skip_checkpt_wr = opts->disable_checkpoints,
+			.disable_summary = opts->disable_summaries,
 		},
 	};
 
@@ -396,7 +397,7 @@ static int init_yaffs_dev(struct mtd_ctx *ctx, const struct opts *opts,
 		  "total_bytes_per_chunk=%d, chunks_per_block=%d, "
 		  "spare_bytes_per_chunk=%d, end_block=%d, is_yaffs2=%d, "
 		  "inband_tags=%d, no_tags_ecc=%d, skip_checkpt_rd=%d, "
-		  "skip_checkpt_wr=%d",
+		  "skip_checkpt_wr=%d, disable_summary=%d",
 		  ctx->yaffs_dev->param.total_bytes_per_chunk,
 		  ctx->yaffs_dev->param.chunks_per_block,
 		  ctx->yaffs_dev->param.spare_bytes_per_chunk,
@@ -405,7 +406,8 @@ static int init_yaffs_dev(struct mtd_ctx *ctx, const struct opts *opts,
 		  ctx->yaffs_dev->param.inband_tags,
 		  ctx->yaffs_dev->param.no_tags_ecc,
 		  ctx->yaffs_dev->param.skip_checkpt_rd,
-		  ctx->yaffs_dev->param.skip_checkpt_wr);
+		  ctx->yaffs_dev->param.skip_checkpt_wr,
+		  ctx->yaffs_dev->param.disable_summary);
 
 	return 0;
 }

--- a/src/options.c
+++ b/src/options.c
@@ -90,7 +90,7 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 		.block_size = SIZE_UNSPECIFIED,
 	};
 
-	while ((opt = getopt(argc, argv, "B:C:d:Ehi:m:o:PrTvw")) != -1) {
+	while ((opt = getopt(argc, argv, "B:C:d:Ehi:m:o:PrSTvw")) != -1) {
 		switch (opt) {
 		case 'B':
 			if (opts->block_size != SIZE_UNSPECIFIED) {
@@ -162,6 +162,13 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 				return -1;
 			}
 			opts->mode = PROGRAM_MODE_READ;
+			break;
+		case 'S':
+			if (opts->disable_summaries) {
+				log("-S can only be used once");
+				return -1;
+			}
+			opts->disable_summaries = true;
 			break;
 		case 'T':
 			if (opts->force_inband_tags) {

--- a/src/options.h
+++ b/src/options.h
@@ -18,6 +18,7 @@
 	"[ -T ] "                                                              \
 	"[ -E ] "                                                              \
 	"[ -P ] "                                                              \
+	"[ -S ] "                                                              \
 	"[ -v ] "                                                              \
 	"[ -h ] "                                                              \
 	"\n\n"                                                                 \
@@ -33,6 +34,7 @@
 	"    -T  force inband tags\n"                                          \
 	"    -E  disable ECC for tags\n"                                       \
 	"    -P  disable Yaffs2 checkpoints\n"                                 \
+	"    -S  disable writing Yaffs2 summaries\n"                           \
 	"    -v  verbose output (can be used up to two times)\n"               \
 	"    -h  show usage information and exit\n"
 
@@ -56,6 +58,7 @@ struct opts {
 	bool force_inband_tags;
 	bool disable_ecc_for_tags;
 	bool disable_checkpoints;
+	bool disable_summaries;
 };
 
 void options_parse_env(void);


### PR DESCRIPTION
By default, Yaffs2 code stores a so-called summary at the end of each block.  These summaries are arrays containing the useful parts of the tags for the chunks in a given block.  Storing tag data in such a condensed form enables retrieving all the tags for a given block in a single read.

Summaries are merely a performance optimization and maintaining them requires extra storage space.  Add a new command-line option, `-S`, which prevents summaries from being written, saving some storage space at the cost of slower file system scanning.  Update `README.md` accordingly.