### PR TITLE
Support forcing byte order

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ options are:
     storage space.  If desired, writing summaries can be disabled using
     the `-S` command-line option.
 
+  - Byte order (`-L` to force little-endian byte order, `-M` to force
+    big-endian byte order).  By default, Yafut assumes that the byte
+    order used on the MTD is the same as the byte order used by the host
+    CPU.  This can be overridden if necessary, allowing little-endian
+    hosts to operate on big-endian file systems and vice versa.
+
 ### Which Yaffs file system versions does this tool work with?
 
 Yaffs code that Yafut builds upon supports both Yaffs1 and Yaffs2 file

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -390,6 +390,7 @@ static int init_yaffs_dev(struct mtd_ctx *ctx, const struct opts *opts,
 			.skip_checkpt_rd = opts->disable_checkpoints,
 			.skip_checkpt_wr = opts->disable_checkpoints,
 			.disable_summary = opts->disable_summaries,
+			.stored_endian = opts->byte_order,
 		},
 	};
 
@@ -397,7 +398,7 @@ static int init_yaffs_dev(struct mtd_ctx *ctx, const struct opts *opts,
 		  "total_bytes_per_chunk=%d, chunks_per_block=%d, "
 		  "spare_bytes_per_chunk=%d, end_block=%d, is_yaffs2=%d, "
 		  "inband_tags=%d, no_tags_ecc=%d, skip_checkpt_rd=%d, "
-		  "skip_checkpt_wr=%d, disable_summary=%d",
+		  "skip_checkpt_wr=%d, disable_summary=%d, stored_endian=%d",
 		  ctx->yaffs_dev->param.total_bytes_per_chunk,
 		  ctx->yaffs_dev->param.chunks_per_block,
 		  ctx->yaffs_dev->param.spare_bytes_per_chunk,
@@ -407,7 +408,8 @@ static int init_yaffs_dev(struct mtd_ctx *ctx, const struct opts *opts,
 		  ctx->yaffs_dev->param.no_tags_ecc,
 		  ctx->yaffs_dev->param.skip_checkpt_rd,
 		  ctx->yaffs_dev->param.skip_checkpt_wr,
-		  ctx->yaffs_dev->param.disable_summary);
+		  ctx->yaffs_dev->param.disable_summary,
+		  ctx->yaffs_dev->param.stored_endian);
 
 	return 0;
 }

--- a/src/options.c
+++ b/src/options.c
@@ -88,9 +88,10 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 		.dst_mode = FILE_MODE_UNSPECIFIED,
 		.chunk_size = SIZE_UNSPECIFIED,
 		.block_size = SIZE_UNSPECIFIED,
+		.byte_order = BYTE_ORDER_CPU,
 	};
 
-	while ((opt = getopt(argc, argv, "B:C:d:Ehi:m:o:PrSTvw")) != -1) {
+	while ((opt = getopt(argc, argv, "B:C:d:Ehi:LMm:o:PrSTvw")) != -1) {
 		switch (opt) {
 		case 'B':
 			if (opts->block_size != SIZE_UNSPECIFIED) {
@@ -132,6 +133,20 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 				return -1;
 			}
 			opts->src_path = optarg;
+			break;
+		case 'L':
+			if (opts->byte_order != BYTE_ORDER_CPU) {
+				log("-L/-M can only be used once");
+				return -1;
+			}
+			opts->byte_order = BYTE_ORDER_LITTLE_ENDIAN;
+			break;
+		case 'M':
+			if (opts->byte_order != BYTE_ORDER_CPU) {
+				log("-L/-M can only be used once");
+				return -1;
+			}
+			opts->byte_order = BYTE_ORDER_BIG_ENDIAN;
 			break;
 		case 'm':
 			if (opts->dst_mode != FILE_MODE_UNSPECIFIED) {

--- a/src/options.h
+++ b/src/options.h
@@ -19,6 +19,8 @@
 	"[ -E ] "                                                              \
 	"[ -P ] "                                                              \
 	"[ -S ] "                                                              \
+	"[ -L ] "                                                              \
+	"[ -M ] "                                                              \
 	"[ -v ] "                                                              \
 	"[ -h ] "                                                              \
 	"\n\n"                                                                 \
@@ -35,6 +37,8 @@
 	"    -E  disable ECC for tags\n"                                       \
 	"    -P  disable Yaffs2 checkpoints\n"                                 \
 	"    -S  disable writing Yaffs2 summaries\n"                           \
+	"    -L  force little-endian byte order\n"                             \
+	"    -M  force big-endian byte order\n"                                \
 	"    -v  verbose output (can be used up to two times)\n"               \
 	"    -h  show usage information and exit\n"
 
@@ -42,6 +46,12 @@ enum program_mode {
 	PROGRAM_MODE_UNSPECIFIED,
 	PROGRAM_MODE_READ,
 	PROGRAM_MODE_WRITE,
+};
+
+enum byte_order {
+	BYTE_ORDER_CPU = 0,
+	BYTE_ORDER_LITTLE_ENDIAN = 1,
+	BYTE_ORDER_BIG_ENDIAN = 2,
 };
 
 #define FILE_MODE_UNSPECIFIED -1
@@ -59,6 +69,7 @@ struct opts {
 	bool disable_ecc_for_tags;
 	bool disable_checkpoints;
 	bool disable_summaries;
+	enum byte_order byte_order;
 };
 
 void options_parse_env(void);


### PR DESCRIPTION
Add two new command-line options, `-L` and `-M`, which allow forcing Yaffs code to assume little-endian or big-endian byte order, respectively. This enables little-endian hosts to operate on big-endian file system and vice versa.  If neither of the new options is used, host CPU byte order is assumed by default.  Update `README.md` accordingly.

Note that Yaffs2 source code must be patched in order for cross-endian operations to work for file systems that include ECC data for tags.  Unfortunately, Yaffs1 code is affected by the same issue in a different location, where it is not as easy to fix as for Yaffs2, nor is it likely that it ever will be as Yaffs1 code is currently pretty much set in stone.  Given that, a Yaffs1 patch for this deficiency was never prepared and Yafut is currently only able to operate on Yaffs2 file systems in an endian-portable manner.
