### PR TITLE
Update Docker images used by build tests

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        image: ['alpine:3.17', 'debian:11', 'fedora:37', 'redhat/ubi9:latest', 'ubuntu:22.04']
+        image: ['alpine:3.19', 'debian:12', 'fedora:40', 'redhat/ubi9:latest', 'ubuntu:24.04']
         compiler: ['clang', 'gcc']
     container: ${{ matrix.image }}
     name: Build (${{ matrix.image }}, ${{ matrix.compiler }})

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -6,6 +6,7 @@ name: Source code checks
 on:
   pull_request:
     paths:
+      - '.github/workflows/code.yml'
       - 'src/**'
   push:
     branches:


### PR DESCRIPTION
Update the Docker images used by the `build` workflow to ensure that Yafut compiles on the latest available version of each tested operating system.