### PR TITLE
Fix basename() implicit declaration

### DIFF
--- a/src/mtd.c
+++ b/src/mtd.c
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <mtd/mtd-user.h>
+#include <libgen.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
While compiling yafut in OpenWrt GCC will print:
[26/31] Building C object CMakeFiles/yafut.dir/src/mtd.c.o /home/robimarko/Building/RB5009/openwrt/build_dir/target-aarch64_cortex-a72_musl/yafut-2024.05.13~290b7580/src/mtd.c: In function 'read_oobavail_from_sysfs': /home/robimarko/Building/RB5009/openwrt/build_dir/target-aarch64_cortex-a72_musl/yafut-2024.05.13~290b7580/src/mtd.c:128:24: warning: implicit declaration of function 'basename' [-Wimplicit-function-declaration]
  128 |                        basename(strdup(mtd_path)));
      |                        ^~~~~~~~
/home/robimarko/Building/RB5009/openwrt/build_dir/target-aarch64_cortex-a72_musl/yafut-2024.05.13~290b7580/src/mtd.c:127:61: warning: format '%s' expects argument of type 'char *', but argument 4 has type 'int' [-Wformat=]
  127 |         ret = snprintf(path, sizeof(path), "/sys/class/mtd/%s/oobavail",
      |                                                            ~^
      |                                                             |
      |                                                             char *
      |                                                            %d
  128 |                        basename(strdup(mtd_path)));
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                        |
      |                        int
[31/31] Linking C executable yafut

It will somehow still compile, but trying to use yafut on the device will lead to instant Segmentation fault.

So, lets simply include the required <libgen.h> header that provides basename.

Fixes: #23