### PR TITLE
Add a macro for logging debug messages

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -38,9 +38,13 @@ int log_format(char *buf, size_t buf_size, const char *fmt, ...) {
  * information.  For logging specific error codes (e.g. errno values), use
  * log_error_location() instead.
  */
-void log_location(const char *file, int line, const char *func, const char *fmt,
-		  ...) {
+void log_location(const char *file, int line, const char *func,
+		  int message_log_level, const char *fmt, ...) {
 	va_list args;
+
+	if (log_level < message_log_level) {
+		return;
+	}
 
 	va_start(args, fmt);
 	log_location_varargs(file, line, func, fmt, args);

--- a/src/log.h
+++ b/src/log.h
@@ -10,6 +10,9 @@
 #define log(fmt, ...)                                                          \
 	log_location(__FILE__, __LINE__, __func__, 0, fmt, ##__VA_ARGS__)
 
+#define log_debug(fmt, ...)                                                    \
+	log_location(__FILE__, __LINE__, __func__, 1, fmt, ##__VA_ARGS__)
+
 #define log_error(err, fmt, ...)                                               \
 	log_error_location(__FILE__, __LINE__, __func__, err, fmt,             \
 			   ##__VA_ARGS__)

--- a/src/log.h
+++ b/src/log.h
@@ -8,7 +8,7 @@
 #include <stddef.h>
 
 #define log(fmt, ...)                                                          \
-	log_location(__FILE__, __LINE__, __func__, fmt, ##__VA_ARGS__)
+	log_location(__FILE__, __LINE__, __func__, 0, fmt, ##__VA_ARGS__)
 
 #define log_error(err, fmt, ...)                                               \
 	log_error_location(__FILE__, __LINE__, __func__, err, fmt,             \
@@ -17,8 +17,8 @@
 extern int log_level;
 
 int log_format(char *buf, size_t buf_size, const char *fmt, ...);
-void log_location(const char *file, int line, const char *func, const char *fmt,
-		  ...);
+void log_location(const char *file, int line, const char *func,
+		  int message_log_level, const char *fmt, ...);
 void log_location_varargs(const char *file, int line, const char *func,
 			  const char *fmt, va_list args);
 void log_error_location(const char *file, int line, const char *func, int err,

--- a/src/util.c
+++ b/src/util.c
@@ -16,7 +16,7 @@
  */
 int util_get_errno_location(const char *file, int line, const char *func) {
 	if (errno <= 0) {
-		log_location(file, line, func,
+		log_location(file, line, func, 0,
 			     "errno unexpectedly set to %d, aborting", errno);
 		abort();
 	}


### PR DESCRIPTION
Add a new preprocessor macro, log_debug(), which emits the message passed to it only if the global logging level (increased using the -v command-line option) is at least 1.  This enables all code modules to produce debug messages in a consistent way.
