### PR TITLE
Portability improvements for a flash-free yafut variant on non-Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+include(CMakeDependentOption)
+include(CMakePushCheckState)
 include(CheckTypeSize)
 
 project(
@@ -14,6 +16,16 @@ project(
 check_type_size(loff_t LOFF_T)
 if(NOT HAVE_LOFF_T)
 	add_definitions(-DY_LOFF_T=off_t)
+endif()
+
+cmake_push_check_state()
+set(CMAKE_EXTRA_INCLUDE_FILES mtd/mtd-user.h)
+check_type_size(mtd_info_t MTD_INFO_T)
+cmake_pop_check_state()
+cmake_dependent_option(
+	WITH_MTD_DEVICE "Include support for MTD devices" ON HAVE_MTD_INFO_T OFF)
+if(NOT WITH_MTD_DEVICE)
+	add_definitions(-DNO_MTD_DEVICE)
 endif()
 
 execute_process(
@@ -68,21 +80,26 @@ add_executable(
 	src/file.c
 	src/file_driver_posix.c
 	src/file_driver_yaffs.c
-	src/ioctl.c
 	src/layout.c
 	src/log.c
 	src/main.c
 	src/options.c
 	src/storage.c
 	src/storage_driver_image.c
-	src/storage_driver_nand.c
-	src/storage_driver_nor.c
 	src/util.c
 	src/yaffs_glue.c
 	src/ydriver.c
-	src/ydriver_ioctl.c
 	src/ydriver_posix.c
 )
+
+if(WITH_MTD_DEVICE)
+	target_sources(yafut PRIVATE
+		src/ioctl.c
+		src/storage_driver_nand.c
+		src/storage_driver_nor.c
+		src/ydriver_ioctl.c
+		)
+endif()
 
 set_target_properties(
 	yafut

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,17 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+include(CheckTypeSize)
+
 project(
 	yafut
 	LANGUAGES C
 )
+
+check_type_size(loff_t LOFF_T)
+if(NOT HAVE_LOFF_T)
+	add_definitions(-DY_LOFF_T=off_t)
+endif()
 
 execute_process(
 	COMMAND sh handle_common.sh copy

--- a/src/file.h
+++ b/src/file.h
@@ -8,7 +8,6 @@
 
 enum file_type {
 	FILE_TYPE_POSIX,
-	FILE_TYPE_MTD,
 	FILE_TYPE_YAFFS,
 };
 

--- a/src/options.c
+++ b/src/options.c
@@ -226,7 +226,11 @@ int options_validate(const struct opts *opts) {
 	case PROGRAM_MODE_READ:
 	case PROGRAM_MODE_WRITE:
 		if (!opts->device_path) {
-			log("MTD device path not specified, use -d");
+#if defined(NO_MTD_DEVICE)
+			log("Image path not specified, use -d");
+#else
+			log("MTD device/image path not specified, use -d");
+#endif
 			return -1;
 		}
 		if (!opts->src_path) {

--- a/src/options.h
+++ b/src/options.h
@@ -6,9 +6,20 @@
 
 #include <stdbool.h>
 
+#if defined(NO_MTD_DEVICE)
+#define USAGE_FLAG_D "-d /path/to/yaffs.img "
+#define USAGE_DESC_D "    -d  path to the Yaffs image to use\n"
+#define USAGE_MTDIMAGE "image"
+#else
+#define USAGE_FLAG_D "-d { /dev/mtdX | /path/to/yaffs.img } "
+#define USAGE_DESC_D                                                           \
+	"    -d  path to the MTD character device or Yaffs image to use\n"
+#define USAGE_MTDIMAGE "MTD/image"
+#endif
+
 #define USAGE_MSG                                                              \
 	"Usage: %s "                                                           \
-	"-d { /dev/mtdX | /path/to/yaffs.img } "                               \
+	USAGE_FLAG_D                                                           \
 	"{ -r | -w } "                                                         \
 	"-i <src> "                                                            \
 	"-o <dst> "                                                            \
@@ -24,9 +35,9 @@
 	"[ -v ] "                                                              \
 	"[ -h ] "                                                              \
 	"\n\n"                                                                 \
-	"    -d  path to the MTD character device (or Yaffs image) to use\n"   \
-	"    -r  read a file from the MTD into a local file\n"                 \
-	"    -w  write a local file to a file on the MTD\n"                    \
+	USAGE_DESC_D                                                           \
+	"    -r  read a file from the " USAGE_MTDIMAGE " into a local file\n"  \
+	"    -w  write a local file to a file on the " USAGE_MTDIMAGE "\n"     \
 	"    -i  path to the source file (use '-' to read from stdin)\n"       \
 	"    -o  path to the destination file (use '-' to write to stdout)\n"  \
 	"    -m  set destination file access permissions to <mode> (octal)\n"  \

--- a/src/storage.c
+++ b/src/storage.c
@@ -4,7 +4,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <mtd/mtd-user.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
@@ -12,17 +11,22 @@
 
 #include <yaffs_guts.h>
 
-#include "ioctl.h"
 #include "layout.h"
 #include "log.h"
 #include "options.h"
 #include "storage.h"
 #include "storage_driver.h"
 #include "storage_driver_image.h"
-#include "storage_driver_nand.h"
-#include "storage_driver_nor.h"
 #include "util.h"
 #include "ydriver.h"
+
+#if !defined(NO_MTD_DEVICE)
+#include <mtd/mtd-user.h>
+
+#include "ioctl.h"
+#include "storage_driver_nand.h"
+#include "storage_driver_nor.h"
+#endif
 
 /*
  * This module serves as a focal point for lower-level abstraction layers,
@@ -45,8 +49,10 @@
  */
 
 static const struct storage_driver *storage_drivers[] = {
+#if !defined(NO_MTD_DEVICE)
 	&storage_driver_nand,
 	&storage_driver_nor,
+#endif
 	&storage_driver_image,
 };
 
@@ -92,6 +98,8 @@ static int storage_probe_stat(struct storage *storage) {
 	return 0;
 }
 
+#if !defined(NO_MTD_DEVICE)
+
 static void storage_probe_mtd_info(struct storage *storage) {
 	struct mtd_info_user *mtd_info = &storage->probe_info.mtd_info;
 	int ret;
@@ -110,6 +118,8 @@ static void storage_probe_mtd_info(struct storage *storage) {
 		  mtd_info->erasesize, mtd_info->writesize, mtd_info->oobsize);
 }
 
+#endif
+
 static int storage_probe(struct storage *storage) {
 	int ret;
 
@@ -118,7 +128,9 @@ static int storage_probe(struct storage *storage) {
 		return ret;
 	}
 
+#if !defined(NO_MTD_DEVICE)
 	storage_probe_mtd_info(storage);
+#endif
 
 	return ret;
 }

--- a/src/storage_driver.h
+++ b/src/storage_driver.h
@@ -4,11 +4,14 @@
 
 #pragma once
 
-#include <mtd/mtd-user.h>
 #include <sys/stat.h>
 
 #include "layout.h"
 #include "ydriver.h"
+
+#if !defined(NO_MTD_DEVICE)
+#include <mtd/mtd-user.h>
+#endif
 
 /*
  * The structure passed to each storage driver during the storage driver
@@ -18,7 +21,9 @@
  */
 struct storage_probe_info {
 	struct stat stat;
+#if !defined(NO_MTD_DEVICE)
 	struct mtd_info_user mtd_info;
+#endif
 };
 
 /*

--- a/src/ydriver.c
+++ b/src/ydriver.c
@@ -91,12 +91,14 @@ long long ydriver_get_data_offset(const struct ydriver_data *ydriver_data,
  */
 int ydriver_get_ecc_result(int read_result, enum yaffs_ecc_result *ecc_result) {
 	switch (read_result) {
+#if !defined(NO_MTD_DEVICE)
 	case -EUCLEAN:
 		*ecc_result = YAFFS_ECC_RESULT_FIXED;
 		return YAFFS_OK;
 	case -EBADMSG:
 		*ecc_result = YAFFS_ECC_RESULT_UNFIXED;
 		return YAFFS_FAIL;
+#endif
 	case 0:
 		*ecc_result = YAFFS_ECC_RESULT_NO_ERROR;
 		return YAFFS_OK;


### PR DESCRIPTION
`yafut` is useful to operate on yaffs images directly, even without MTD (NOR/NAND) flash support. Although the flash interface is Linux-specific, the recent refactoring nicely separated most flash-specific code out to the point that it’s easily excluded on non-Linux systems. With minor additional build changes, it’s possible to build an image-only variant of `yafut` on non-Linux systems.

This is useful in the OpenWrt build: OpenWrt can be built on macOS, but since the recent transition from `kernel2minor` to `yafut`, it’s become impossible to build Mikrotik images on macOS.

This pull request isolates the flash-specific code so that it can be disabled on non-Linux systems. To further improve portability, it also allows `off_t` to be used in the place of the Linux-specific `loff_t` on systems that don’t have the latter.

I’ve tested this to successfully build and deploy OpenWrt ipq40xx/mikrotik,wap-ac images from a macOS build system.