### PR TITLE
Enable building on macOS

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -16,12 +16,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image: ['alpine:3.19', 'debian:12', 'fedora:40', 'redhat/ubi9:latest', 'ubuntu:24.04']
         compiler: ['clang', 'gcc']
-    container: ${{ matrix.image }}
+        include:
+          - image: 'macos-14'
+            compiler: 'clang'
+    runs-on: ${{ !startsWith(matrix.image, 'macos') && 'ubuntu-22.04' || matrix.image }}
+    container: ${{ !startsWith(matrix.image, 'macos') && matrix.image || null }}
     name: Build (${{ matrix.image }}, ${{ matrix.compiler }})
     steps:
       - name: Update package repository metadata

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,17 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+include(CheckTypeSize)
+
 project(
 	yafut
 	LANGUAGES C
 )
+
+check_type_size(loff_t LOFF_T)
+if(NOT HAVE_LOFF_T)
+	add_definitions(-DY_LOFF_T=off_t)
+endif()
 
 execute_process(
 	COMMAND sh handle_common.sh copy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ if(NOT HAVE_LOFF_T)
 endif()
 
 execute_process(
+	COMMAND sh handle_common.sh clean
+	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/lib/yaffs2/direct/
+)
+
+execute_process(
 	COMMAND sh handle_common.sh copy
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/lib/yaffs2/direct/
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,21 +68,35 @@ add_executable(
 	src/file.c
 	src/file_driver_posix.c
 	src/file_driver_yaffs.c
-	src/ioctl.c
 	src/layout.c
 	src/log.c
 	src/main.c
 	src/options.c
 	src/storage.c
 	src/storage_driver_image.c
-	src/storage_driver_nand.c
-	src/storage_driver_nor.c
 	src/util.c
 	src/yaffs_glue.c
 	src/ydriver.c
-	src/ydriver_ioctl.c
 	src/ydriver_posix.c
 )
+
+if(LINUX)
+	target_sources(
+		yafut
+		PRIVATE
+		src/ioctl.c
+		src/storage_driver_nand.c
+		src/storage_driver_nor.c
+		src/storage_platform_linux.c
+		src/ydriver_ioctl.c
+	)
+else()
+	target_sources(
+		yafut
+		PRIVATE
+		src/storage_platform_generic.c
+	)
+endif()
 
 set_target_properties(
 	yafut

--- a/src/file.h
+++ b/src/file.h
@@ -8,7 +8,6 @@
 
 enum file_type {
 	FILE_TYPE_POSIX,
-	FILE_TYPE_MTD,
 	FILE_TYPE_YAFFS,
 };
 

--- a/src/storage.c
+++ b/src/storage.c
@@ -44,10 +44,11 @@
  *     storage driver and a data structure containing layout information.
  */
 
-static const struct storage_driver *storage_drivers[] = {
+static const struct storage_driver *storage_platform_drivers[] = {
 	&storage_driver_nand,
 	&storage_driver_nor,
 	&storage_driver_image,
+	NULL,
 };
 
 static void storage_init(struct storage *storage, const struct opts *opts) {
@@ -158,10 +159,10 @@ static int storage_probe(struct storage *storage) {
 }
 
 static int storage_match_driver(struct storage *storage) {
-	int driver_count = sizeof(storage_drivers) / sizeof(storage_drivers[0]);
+	const struct storage_driver *driver;
 
-	for (int i = 0; i < driver_count; i++) {
-		const struct storage_driver *driver = storage_drivers[i];
+	for (int i = 0; storage_platform_drivers[i] != NULL; i++) {
+		driver = storage_platform_drivers[i];
 
 		log_debug("trying driver %s", driver->name);
 

--- a/src/storage_driver.h
+++ b/src/storage_driver.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <mtd/mtd-user.h>
 #include <sys/stat.h>
 
 #include "layout.h"
@@ -18,7 +17,7 @@
  */
 struct storage_probe_info {
 	struct stat stat;
-	struct mtd_info_user mtd_info;
+	void *platform_data;
 };
 
 /*

--- a/src/storage_driver_nand.c
+++ b/src/storage_driver_nand.c
@@ -8,7 +8,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include "layout.h"
@@ -19,16 +18,17 @@
 #include "ydriver_ioctl.h"
 
 static bool storage_nand_match(const struct storage_probe_info *probe_info) {
-	return (S_ISCHR(probe_info->stat.st_mode)
-		&& probe_info->mtd_info.oobsize > 0
-		&& probe_info->mtd_info.writesize > 1);
+	struct mtd_info_user *mtd_info = probe_info->platform_data;
+
+	return (mtd_info && mtd_info->oobsize > 0 && mtd_info->writesize > 1);
 }
 
 static int storage_nand_get_total_size(void *callback_data,
 				       unsigned int *total_sizep) {
 	struct storage *storage = callback_data;
+	struct mtd_info_user *mtd_info = storage->probe_info.platform_data;
 
-	*total_sizep = storage->probe_info.mtd_info.size;
+	*total_sizep = mtd_info->size;
 	log_debug("detected storage size: %u bytes", *total_sizep);
 
 	return 0;
@@ -37,8 +37,9 @@ static int storage_nand_get_total_size(void *callback_data,
 static int storage_nand_get_block_size(void *callback_data,
 				       unsigned int *block_sizep) {
 	struct storage *storage = callback_data;
+	struct mtd_info_user *mtd_info = storage->probe_info.platform_data;
 
-	*block_sizep = storage->probe_info.mtd_info.erasesize;
+	*block_sizep = mtd_info->erasesize;
 	log_debug("detected block size: %u bytes", *block_sizep);
 
 	return 0;
@@ -47,8 +48,9 @@ static int storage_nand_get_block_size(void *callback_data,
 static int storage_nand_get_chunk_size(void *callback_data,
 				       unsigned int *chunk_sizep) {
 	struct storage *storage = callback_data;
+	struct mtd_info_user *mtd_info = storage->probe_info.platform_data;
 
-	*chunk_sizep = storage->probe_info.mtd_info.writesize;
+	*chunk_sizep = mtd_info->writesize;
 	log_debug("detected chunk size: %u bytes", *chunk_sizep);
 
 	return 0;
@@ -57,8 +59,9 @@ static int storage_nand_get_chunk_size(void *callback_data,
 static int storage_nand_get_oob_size(void *callback_data,
 				     unsigned int *oob_sizep) {
 	struct storage *storage = callback_data;
+	struct mtd_info_user *mtd_info = storage->probe_info.platform_data;
 
-	*oob_sizep = storage->probe_info.mtd_info.oobsize;
+	*oob_sizep = mtd_info->oobsize;
 	log_debug("detected OOB data size: %u bytes", *oob_sizep);
 
 	return 0;

--- a/src/storage_driver_nor.c
+++ b/src/storage_driver_nor.c
@@ -5,7 +5,6 @@
 #include <fcntl.h>
 #include <mtd/mtd-user.h>
 #include <stdbool.h>
-#include <sys/stat.h>
 
 #include "layout.h"
 #include "log.h"
@@ -15,16 +14,17 @@
 #include "ydriver_posix.h"
 
 static bool storage_nor_match(const struct storage_probe_info *probe_info) {
-	return (S_ISCHR(probe_info->stat.st_mode)
-		&& probe_info->mtd_info.oobsize == 0
-		&& probe_info->mtd_info.writesize == 1);
+	struct mtd_info_user *mtd_info = probe_info->platform_data;
+
+	return (mtd_info && mtd_info->oobsize == 0 && mtd_info->writesize == 1);
 }
 
 static int storage_nor_get_total_size(void *callback_data,
 				      unsigned int *total_sizep) {
 	struct storage *storage = callback_data;
+	struct mtd_info_user *mtd_info = storage->probe_info.platform_data;
 
-	*total_sizep = storage->probe_info.mtd_info.size;
+	*total_sizep = mtd_info->size;
 	log_debug("detected storage size: %u bytes", *total_sizep);
 
 	return 0;

--- a/src/storage_platform.h
+++ b/src/storage_platform.h
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+extern const struct storage_driver *storage_platform_drivers[];
+
+int storage_platform_probe(struct storage *storage);
+void storage_platform_destroy(struct storage *storage);

--- a/src/storage_platform_generic.c
+++ b/src/storage_platform_generic.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <stddef.h>
+
+#include "storage_driver.h"
+#include "storage_driver_image.h"
+#include "storage_platform.h"
+
+const struct storage_driver *storage_platform_drivers[] = {
+	&storage_driver_image,
+	NULL,
+};
+
+int storage_platform_probe(struct storage *storage) {
+	(void)storage;
+
+	return 0;
+}
+
+void storage_platform_destroy(struct storage *storage) {
+	(void)storage;
+}

--- a/src/storage_platform_linux.c
+++ b/src/storage_platform_linux.c
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <errno.h>
+#include <mtd/mtd-user.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+
+#include "ioctl.h"
+#include "log.h"
+#include "storage_driver.h"
+#include "storage_driver_image.h"
+#include "storage_driver_nand.h"
+#include "storage_driver_nor.h"
+#include "storage_platform.h"
+#include "util.h"
+
+const struct storage_driver *storage_platform_drivers[] = {
+	&storage_driver_nand,
+	&storage_driver_nor,
+	&storage_driver_image,
+	NULL,
+};
+
+static int storage_platform_data_get_mtd_info(struct storage *storage,
+					      struct mtd_info_user *mtd_info) {
+	int ret;
+
+	ret = linux_ioctl(storage->fd, MEMGETINFO, mtd_info);
+	if (ret < 0) {
+		ret = util_get_errno();
+		log_debug("unable to get MTD information for %s (error %d: %s)",
+			  storage->path, ret, util_get_error(ret));
+		return ret;
+	}
+
+	log_debug("type=%d, flags=0x%08x, size=%d, erasesize=%d, writesize=%d, "
+		  "oobsize=%d",
+		  mtd_info->type, mtd_info->flags, mtd_info->size,
+		  mtd_info->erasesize, mtd_info->writesize, mtd_info->oobsize);
+
+	return 0;
+}
+
+static int storage_platform_data_instantiate(struct storage *storage) {
+	struct mtd_info_user *mtd_info;
+	int ret;
+
+	mtd_info = calloc(1, sizeof(*mtd_info));
+	if (!mtd_info) {
+		return -ENOMEM;
+	}
+
+	ret = storage_platform_data_get_mtd_info(storage, mtd_info);
+	if (ret < 0) {
+		free(mtd_info);
+		return ret;
+	}
+
+	storage->probe_info.platform_data = mtd_info;
+
+	return 0;
+}
+
+int storage_platform_probe(struct storage *storage) {
+	if (!S_ISCHR(storage->probe_info.stat.st_mode)) {
+		log_debug("%s is not a character device, ioctls suppressed",
+			  storage->path);
+		return 0;
+	}
+
+	return storage_platform_data_instantiate(storage);
+}
+
+void storage_platform_destroy(struct storage *storage) {
+	free(storage->probe_info.platform_data);
+}

--- a/src/ydriver.c
+++ b/src/ydriver.c
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include <errno.h>
 #include <stdio.h>
 
 #include <yaffs_guts.h>
@@ -81,29 +80,6 @@ long long ydriver_get_data_offset(const struct ydriver_data *ydriver_data,
 	chunk_in_block = chunk % chunks_per_block;
 
 	return (block * block_size) + (chunk_in_block * chunk_size);
-}
-
-/*
- * Helper function for the 'read_chunk' callback of a Yaffs driver that
- * translates the result code of a system call into an <ECC result, Yaffs
- * result code> tuple.  Yaffs uses these values to properly handle deficiencies
- * in flash memory.
- */
-int ydriver_get_ecc_result(int read_result, enum yaffs_ecc_result *ecc_result) {
-	switch (read_result) {
-	case -EUCLEAN:
-		*ecc_result = YAFFS_ECC_RESULT_FIXED;
-		return YAFFS_OK;
-	case -EBADMSG:
-		*ecc_result = YAFFS_ECC_RESULT_UNFIXED;
-		return YAFFS_FAIL;
-	case 0:
-		*ecc_result = YAFFS_ECC_RESULT_NO_ERROR;
-		return YAFFS_OK;
-	default:
-		*ecc_result = YAFFS_ECC_RESULT_UNKNOWN;
-		return YAFFS_FAIL;
-	}
 }
 
 static int ydriver_check_bad(struct yaffs_dev *yaffs_device, int block_no) {

--- a/src/ydriver.h
+++ b/src/ydriver.h
@@ -49,4 +49,3 @@ void ydriver_debug_hexdump_location(const char *file, int line,
 				    const char *func, const u8 *buf,
 				    int buf_len, const char *description);
 long long ydriver_get_data_offset(const struct ydriver_data *data, int chunk);
-int ydriver_get_ecc_result(int read_result, enum yaffs_ecc_result *ecc_result);

--- a/src/ydriver_posix.c
+++ b/src/ydriver_posix.c
@@ -71,7 +71,6 @@ int ydriver_posix_read_chunk(struct ydriver_data *ydriver_data, int chunk,
 			     u8 *data, int data_len, u8 *oob, int oob_len,
 			     enum yaffs_ecc_result *ecc_result_out) {
 	long long offset = ydriver_get_data_offset(ydriver_data, chunk);
-	enum yaffs_ecc_result ecc_result;
 	int err = 0;
 	int ret;
 
@@ -89,13 +88,16 @@ int ydriver_posix_read_chunk(struct ydriver_data *ydriver_data, int chunk,
 		  util_get_error(err));
 	ydriver_debug_hexdump(data, data_len, "data");
 
-	ret = ydriver_get_ecc_result(ret < 0 ? ret : 0, &ecc_result);
-
 	if (ecc_result_out) {
-		*ecc_result_out = ecc_result;
+		*ecc_result_out = (ret < 0 ? YAFFS_ECC_RESULT_UNKNOWN
+					   : YAFFS_ECC_RESULT_NO_ERROR);
 	}
 
-	return ret;
+	if (ret < 0) {
+		return YAFFS_FAIL;
+	}
+
+	return YAFFS_OK;
 }
 
 int ydriver_posix_write_chunk(struct ydriver_data *ydriver_data, int chunk,


### PR DESCRIPTION
Linux was the only target platform considered when Yafut was originally designed.  However, as it gained the ability to operate on Yaffs file system images using POSIX APIs, it became potentially useful on other operating systems as well (e.g. macOS).  The obstacle preventing that is the unconditional use of Linux-specific APIs (MTD ioctls and the related structures) in the source code.  Extract all Linux-specific code to a separate module that only gets compiled on that system and make existing Linux-specific modules conditionally-compiled as well.  Implement a generic counterpart of the Linux-specific module to be used on other operating systems (where only Yaffs file system images will be supported).

Originally suggested in #29 by @markmentovai.