### PR TITLE
Support preserving file modification times

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -165,6 +165,22 @@ static int copy_or_set_file_mode(struct copy_operation *copy) {
 	return file_set_mode(copy->dst.file, copy->opts->dst_mode);
 }
 
+static int copy_file_modification_time(struct copy_operation *copy) {
+	unsigned long long src_mtime;
+	int ret;
+
+	if (!copy->opts->preserve_timestamps) {
+		return 0;
+	}
+
+	ret = file_get_mtime(copy->src.file, &src_mtime);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return file_set_mtime(copy->dst.file, src_mtime);
+}
+
 static int copy_perform(struct copy_operation *copy) {
 	int ret;
 
@@ -173,7 +189,12 @@ static int copy_perform(struct copy_operation *copy) {
 		return ret;
 	}
 
-	return copy_or_set_file_mode(copy);
+	ret = copy_or_set_file_mode(copy);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return copy_file_modification_time(copy);
 }
 
 static void copy_destroy(struct copy_operation *copy) {

--- a/src/file.c
+++ b/src/file.c
@@ -91,3 +91,11 @@ int file_get_mode(struct file *file, int *modep) {
 int file_set_mode(struct file *file, int mode) {
 	return file->ops->set_mode(file, mode);
 }
+
+int file_get_mtime(struct file *file, unsigned long long *mtimep) {
+	return file->ops->get_mtime(file, mtimep);
+}
+
+int file_set_mtime(struct file *file, unsigned long long mtime) {
+	return file->ops->set_mtime(file, mtime);
+}

--- a/src/file.h
+++ b/src/file.h
@@ -34,3 +34,6 @@ int file_write(struct file *file, const unsigned char *buf, size_t count);
 
 int file_get_mode(struct file *file, int *modep);
 int file_set_mode(struct file *file, int mode);
+
+int file_get_mtime(struct file *file, unsigned long long *mtimep);
+int file_set_mtime(struct file *file, unsigned long long mtime);

--- a/src/file_driver.h
+++ b/src/file_driver.h
@@ -16,6 +16,8 @@ struct file_ops {
 	int (*write)(struct file *file, const unsigned char *buf, size_t count);
 	int (*get_mode)(struct file *file, int *modep);
 	int (*set_mode)(struct file *file, int mode);
+	int (*get_mtime)(struct file *file, unsigned long long *mtimep);
+	int (*set_mtime)(struct file *file, unsigned long long mtime);
 };
 
 struct file {

--- a/src/options.c
+++ b/src/options.c
@@ -91,7 +91,7 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 		.byte_order = BYTE_ORDER_CPU,
 	};
 
-	while ((opt = getopt(argc, argv, "B:C:d:Ehi:LMm:o:PrSTvw")) != -1) {
+	while ((opt = getopt(argc, argv, "B:C:d:Ehi:LMm:o:PrStTvw")) != -1) {
 		switch (opt) {
 		case 'B':
 			if (opts->block_size != SIZE_UNSPECIFIED) {
@@ -184,6 +184,13 @@ int options_parse_cli(int argc, char *argv[], struct opts *opts) {
 				return -1;
 			}
 			opts->disable_summaries = true;
+			break;
+		case 't':
+			if (opts->preserve_timestamps) {
+				log("-t can only be used once");
+				return -1;
+			}
+			opts->preserve_timestamps = true;
 			break;
 		case 'T':
 			if (opts->force_inband_tags) {

--- a/src/options.h
+++ b/src/options.h
@@ -13,6 +13,7 @@
 	"-i <src> "                                                            \
 	"-o <dst> "                                                            \
 	"[ -m <mode> ] "                                                       \
+	"[ -t ] "                                                              \
 	"[ -C <bytes> ] "                                                      \
 	"[ -B <bytes> ] "                                                      \
 	"[ -T ] "                                                              \
@@ -31,6 +32,7 @@
 	"    -o  path to the destination file (use '-' to write to stdout)\n"  \
 	"    -m  set destination file access permissions to <mode> (octal)\n"  \
 	"        (default: copy access permissions from <src>)\n"              \
+	"    -t  preserve file modification times when copying\n"              \
 	"    -C  force Yaffs chunk size to <bytes> (use 'k' suffix for KiB)\n" \
 	"    -B  force Yaffs block size to <bytes> (use 'k' suffix for KiB)\n" \
 	"    -T  force inband tags\n"                                          \
@@ -65,6 +67,7 @@ struct opts {
 	int dst_mode;
 	int chunk_size;
 	int block_size;
+	bool preserve_timestamps;
 	bool force_inband_tags;
 	bool disable_ecc_for_tags;
 	bool disable_checkpoints;


### PR DESCRIPTION
When the Yaffs Direct Interface is used, replacing the contents of an existing file on a Yaffs file system does not automatically cause its last modification time to be updated.

Add a new command-line option, -t, which allows preserving file modification times when copying files from/to a Yaffs file system.  This new feature is not enabled by default because updating a file modification timestamp on a Yaffs file system requires writing an extra data chunk to the underlying storage device.