### PR TITLE
Enable listing Yaffs file system contents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,13 @@ add_executable(
 	src/layout.c
 	src/log.c
 	src/main.c
+	src/object.c
 	src/options.c
+	src/printer.c
+	src/printer_driver_text.c
 	src/storage.c
 	src/storage_driver_image.c
+	src/tree.c
 	src/util.c
 	src/yaffs_glue.c
 	src/ydriver.c

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ copying files from/to Yaffs file system images stored in regular files.
 
 ## Usage Examples
 
+To list the contents of the flash partition represented by the
+character device `/dev/mtd0`, run:
+
+    yafut -d /dev/mtd0 -l
+
 To copy a file called `foo` from the flash partition represented by the
 character device `/dev/mtd1` to a local file called `bar`, run:
 
@@ -140,6 +145,13 @@ options are:
     order used on the MTD is the same as the byte order used by the host
     CPU.  This can be overridden if necessary, allowing little-endian
     hosts to operate on big-endian file systems and vice versa.
+
+### How do I know whether the parameters I used are correct?
+
+If you have reasons to believe that the Yaffs file system you are
+working with is not empty, try listing its contents using the `-l`
+command-line option.  If Yafut lists anything except a `/lost+found`
+directory, the Yaffs layout parameters used are most likely correct.
 
 ### Which Yaffs file system versions does this tool work with?
 

--- a/src/file_driver_yaffs.c
+++ b/src/file_driver_yaffs.c
@@ -11,6 +11,7 @@
 #include "file_driver.h"
 #include "log.h"
 #include "storage.h"
+#include "util.h"
 
 static int file_yaffs_instantiate(const struct file_spec *spec,
 				  void **driver_datap) {
@@ -24,7 +25,7 @@ static int file_yaffs_instantiate(const struct file_spec *spec,
 
 	ret = yaffs_mount_reldev((struct yaffs_dev *)storage);
 	if (ret < 0) {
-		ret = yaffsfs_GetLastError();
+		ret = util_get_yaffs_errno();
 		log_error(ret, "unable to mount Yaffs filesystem");
 		storage_destroy(&storage);
 		return ret;
@@ -43,7 +44,7 @@ static void file_yaffs_destroy(void **driver_datap) {
 
 	ret = yaffs_unmount_reldev((struct yaffs_dev *)storage);
 	if (ret < 0) {
-		ret = yaffsfs_GetLastError();
+		ret = util_get_yaffs_errno();
 		log_error(ret, "error unmounting Yaffs filesystem");
 	}
 
@@ -59,7 +60,7 @@ static int file_yaffs_open(struct file *file, int flags) {
 	log_debug("yaffs_open_reldev, path=%s, ret=%d", file->path, ret);
 
 	if (ret < 0) {
-		ret = yaffsfs_GetLastError();
+		ret = util_get_yaffs_errno();
 		return ret;
 	}
 
@@ -103,7 +104,7 @@ static int file_yaffs_read(struct file *file, unsigned char *buf,
 	log_debug("yaffs_read, fd=%d, count=%d, ret=%d", file->fd, count, ret);
 
 	if (ret < 0) {
-		ret = yaffsfs_GetLastError();
+		ret = util_get_yaffs_errno();
 		log_error(ret, "error reading '%s'", file->path);
 	}
 
@@ -118,7 +119,7 @@ static int file_yaffs_write(struct file *file, const unsigned char *buf,
 	log_debug("yaffs_write, fd=%d, count=%d, ret=%d", file->fd, count, ret);
 
 	if (ret < 0) {
-		ret = yaffsfs_GetLastError();
+		ret = util_get_yaffs_errno();
 		log_error(ret, "error writing '%s'", file->path);
 	}
 
@@ -133,7 +134,7 @@ static int file_yaffs_get_mode(struct file *file, int *modep) {
 	log_debug("yaffs_fstat, fd=%d, ret=%d", file->fd, ret);
 
 	if (ret < 0) {
-		ret = yaffsfs_GetLastError();
+		ret = util_get_yaffs_errno();
 		log_error(ret, "error getting permissions for '%s'",
 			  file->path);
 		return ret;
@@ -153,7 +154,7 @@ static int file_yaffs_set_mode(struct file *file, int mode) {
 		  ret);
 
 	if (ret < 0) {
-		ret = yaffsfs_GetLastError();
+		ret = util_get_yaffs_errno();
 		log_error(ret, "error setting permissions for '%s'",
 			  file->path);
 	}
@@ -169,7 +170,7 @@ static int file_yaffs_get_mtime(struct file *file, unsigned long long *mtimep) {
 	log_debug("yaffs_fstat, fd=%d, ret=%d", file->fd, ret);
 
 	if (ret < 0) {
-		ret = yaffsfs_GetLastError();
+		ret = util_get_yaffs_errno();
 		log_error(ret, "error getting modification time for '%s'",
 			  file->path);
 		return ret;
@@ -189,7 +190,7 @@ int file_yaffs_set_mtime(struct file *file, unsigned long long mtime) {
 	log_debug("yaffs_futime, fd=%d, ret=%d", file->fd, ret);
 
 	if (ret < 0) {
-		ret = yaffsfs_GetLastError();
+		ret = util_get_yaffs_errno();
 		log_error(ret, "error setting modification time for '%s'",
 			  file->path);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 
 #include "copy.h"
 #include "options.h"
+#include "tree.h"
 
 static char *program_name;
 
@@ -15,6 +16,8 @@ static char *program_name;
  */
 static int perform_action(struct opts *opts) {
 	switch (opts->mode) {
+	case PROGRAM_MODE_LIST:
+		return tree_print_based_on_opts(opts);
 	case PROGRAM_MODE_READ:
 	case PROGRAM_MODE_WRITE:
 		return copy_file_based_on_opts(opts);

--- a/src/object.c
+++ b/src/object.c
@@ -1,0 +1,533 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strings.h>
+
+#include <yaffs_guts.h>
+#include <yaffsfs.h>
+
+#include "log.h"
+#include "object.h"
+#include "storage.h"
+#include "util.h"
+
+static int object_recursive_discover(struct object *object,
+				     const struct storage *storage);
+static void object_recursive_free(struct object *object);
+
+const char *object_get_path(const struct object *object) {
+	if (object->path_ptr) {
+		return object->path_ptr;
+	}
+
+	return object->path_array;
+}
+
+int object_recursive_instantiate(struct object **objectp) {
+	struct object *object;
+
+	object = calloc(1, sizeof(*object));
+	if (!object) {
+		return -ENOMEM;
+	}
+
+	*object = (struct object){.type = LIST_OBJECT_TYPE_ROOT};
+
+	*objectp = object;
+
+	return 0;
+}
+
+static void object_free_directory(struct object *object) {
+	struct object_directory *directory = &object->data.directory;
+
+	for (unsigned int i = 0; i < directory->children_count; i++) {
+		object_recursive_free(&directory->children[i]);
+	}
+
+	free(directory->children);
+}
+
+static void object_free_symlink(struct object *object) {
+	struct object_symlink *symlink = &object->data.symlink;
+
+	free(symlink->target);
+}
+
+static void (*const object_free_callbacks[])(struct object *) = {
+	[LIST_OBJECT_TYPE_ROOT] = object_free_directory,
+	[LIST_OBJECT_TYPE_DIRECTORY] = object_free_directory,
+	[LIST_OBJECT_TYPE_SYMLINK] = object_free_symlink,
+};
+
+static void object_recursive_free(struct object *object) {
+	void (*free_callback)(struct object *);
+
+	free_callback = object_free_callbacks[object->type];
+	if (free_callback) {
+		free_callback(object);
+	}
+
+	free(object->path_ptr);
+}
+
+void object_recursive_destroy(struct object **objectp) {
+	struct object *object = *objectp;
+
+	*objectp = NULL;
+
+	object_recursive_free(object);
+
+	free(object);
+}
+
+static int object_get_new_children_size(const struct object *object,
+					unsigned int *children_countp,
+					unsigned int *children_sizep) {
+	const struct object_directory *directory = &object->data.directory;
+	unsigned int new_children_count;
+	unsigned int new_children_size;
+	unsigned int cur_children_size;
+	size_t child_size;
+
+	new_children_count = directory->children_count > 0
+				     ? directory->children_count * 2
+				     : 4;
+
+	child_size = sizeof(directory->children[0]);
+	new_children_size = new_children_count * child_size;
+	cur_children_size = directory->children_count * child_size;
+
+	if (new_children_size < cur_children_size) {
+		log("unable to allocate more than %u bytes for '%s'",
+		    cur_children_size, object_get_path(object));
+		return -ENOMEM;
+	}
+
+	*children_countp = new_children_count;
+	*children_sizep = new_children_size;
+
+	return 0;
+}
+
+static int object_reallocate_children(struct object *object,
+				      unsigned int new_children_size) {
+	struct object_directory *directory = &object->data.directory;
+	struct object *new_children;
+	int ret;
+
+	new_children = realloc(directory->children, new_children_size);
+	if (!new_children) {
+		ret = util_get_errno();
+		log_error(ret, "unable to allocate %u bytes for '%s'",
+			  new_children_size, object_get_path(object));
+		return ret;
+	}
+
+	directory->children = new_children;
+
+	return 0;
+}
+
+static int object_allocate_more_children(struct object *object) {
+	struct object_directory *directory = &object->data.directory;
+	unsigned int new_children_count;
+	unsigned int new_children_size;
+	int ret;
+
+	ret = object_get_new_children_size(object, &new_children_count,
+					   &new_children_size);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = object_reallocate_children(object, new_children_size);
+	if (ret < 0) {
+		return ret;
+	}
+
+	directory->children_allocated = new_children_count;
+
+	return 0;
+}
+
+static int object_ensure_children_available(struct object *object) {
+	struct object_directory *directory = &object->data.directory;
+
+	if (directory->children_count < directory->children_allocated) {
+		return 0;
+	}
+
+	return object_allocate_more_children(object);
+}
+
+static void object_get_next_available_child(struct object *parent_object,
+					    struct object **objectp) {
+	struct object_directory *parent_directory;
+	struct object *object;
+
+	parent_directory = &parent_object->data.directory;
+
+	object = &parent_directory->children[parent_directory->children_count];
+	*object = (struct object){};
+
+	parent_directory->children_count++;
+
+	*objectp = object;
+}
+
+static int object_get_child(struct object *parent_object,
+			    struct object **objectp) {
+	int ret;
+
+	ret = object_ensure_children_available(parent_object);
+	if (ret < 0) {
+		return ret;
+	}
+
+	object_get_next_available_child(parent_object, objectp);
+
+	return 0;
+}
+
+static void object_set_path_array(struct object *object,
+				  const char *directory_path,
+				  const char *entry_name) {
+	(void)snprintf(object->path_array, sizeof(object->path_array), "%s/%s",
+		       directory_path, entry_name);
+}
+
+static int object_set_path_ptr(struct object *object,
+			       const char *directory_path,
+			       const char *entry_name, int path_length) {
+	object->path_ptr = calloc(1, path_length + 1);
+	if (!object->path_ptr) {
+		return -ENOMEM;
+	}
+
+	(void)snprintf(object->path_ptr, path_length + 1, "%s/%s",
+		       directory_path, entry_name);
+
+	return 0;
+}
+
+static int object_set_path(struct object *object, const char *directory_path,
+			   const char *entry_name) {
+	int path_length;
+
+	path_length = snprintf(NULL, 0, "%s/%s", directory_path, entry_name);
+
+	if ((unsigned int)path_length <= sizeof(object->path_array) - 1) {
+		object_set_path_array(object, directory_path, entry_name);
+		return 0;
+	}
+
+	return object_set_path_ptr(object, directory_path, entry_name,
+				   path_length);
+}
+
+static int object_stat(const struct storage *storage, struct object *object) {
+	struct yaffs_stat stat;
+	int ret;
+
+	ret = yaffs_lstat_reldev((struct yaffs_dev *)storage,
+				 object_get_path(object), &stat);
+	if (ret < 0) {
+		ret = util_get_yaffs_errno();
+		log_error(ret, "yaffs_lstat_reldev() failed for '%s'",
+			  object_get_path(object));
+		return ret;
+	}
+
+	if (S_ISREG(stat.st_mode)) {
+		object->type = LIST_OBJECT_TYPE_FILE;
+	} else if (S_ISDIR(stat.st_mode)) {
+		object->type = LIST_OBJECT_TYPE_DIRECTORY;
+	} else if (S_ISLNK(stat.st_mode)) {
+		object->type = LIST_OBJECT_TYPE_SYMLINK;
+	}
+
+	object->mode = stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+	object->size = stat.st_size;
+	object->mtime = stat.yst_mtime;
+
+	return 0;
+}
+
+static int object_initialize_child(struct object *object,
+				   const struct storage *storage,
+				   const char *directory_path,
+				   const char *entry_name) {
+	int ret;
+
+	ret = object_set_path(object, directory_path, entry_name);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return object_stat(storage, object);
+}
+
+static int object_create_from_directory_entry(
+	const struct storage *storage, struct object *parent_object,
+	const struct yaffs_dirent *directory_entry, struct object **objectp) {
+	struct object *object;
+	int ret;
+
+	ret = object_get_child(parent_object, &object);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = object_initialize_child(object, storage,
+				      object_get_path(parent_object),
+				      directory_entry->d_name);
+	if (ret < 0) {
+		return ret;
+	}
+
+	*objectp = object;
+
+	return 0;
+}
+
+static int object_process_file(struct object *object,
+			       const struct storage *storage) {
+	struct object_file *file = &object->data.file;
+	(void)storage;
+
+	file->executable = !!(object->mode & S_IXUSR);
+
+	return 0;
+}
+
+static int object_process_directory(struct object *object,
+				    const struct storage *storage) {
+	return object_recursive_discover(object, storage);
+}
+
+static int object_get_symlink_target(const struct object *object,
+				     const struct storage *storage,
+				     char *symlink_target,
+				     size_t symlink_target_size) {
+	int ret;
+
+	ret = yaffs_readlink_reldir(((struct yaffs_dev *)storage)->root_dir,
+				    object_get_path(object), symlink_target,
+				    symlink_target_size);
+	if (ret < 0) {
+		ret = util_get_yaffs_errno();
+		log_error(ret, "yaffs_readlink() failed for '%s'",
+			  object_get_path(object));
+	}
+
+	return ret;
+}
+
+static int object_set_symlink_target(struct object *object,
+				     const char *symlink_target) {
+	struct object_symlink *symlink = &object->data.symlink;
+	size_t symlink_target_size = object->size + 1;
+
+	symlink->target = calloc(1, symlink_target_size);
+	if (!symlink->target) {
+		return -ENOMEM;
+	}
+
+	(void)snprintf(symlink->target, symlink_target_size, "%s",
+		       symlink_target);
+
+	return 0;
+}
+
+static void object_detect_broken_symlink(struct object *object,
+					 const struct storage *storage) {
+
+	struct yaffs_stat stat;
+	int ret;
+
+	ret = yaffs_lstat_reldev((struct yaffs_dev *)storage,
+				 object->data.symlink.target, &stat);
+	if (ret < 0) {
+		object->data.symlink.broken = true;
+	}
+}
+
+static int object_process_symlink(struct object *object,
+				  const struct storage *storage) {
+	char symlink_target[256];
+	int ret;
+
+	ret = object_get_symlink_target(object, storage, symlink_target,
+					sizeof(symlink_target));
+	if (ret < 0) {
+		return ret;
+	}
+
+	object_set_symlink_target(object, symlink_target);
+
+	object_detect_broken_symlink(object, storage);
+
+	return 0;
+}
+
+static int (*const object_process_callbacks[])(struct object *,
+					       const struct storage *)
+	= {
+		[LIST_OBJECT_TYPE_FILE] = object_process_file,
+		[LIST_OBJECT_TYPE_DIRECTORY] = object_process_directory,
+		[LIST_OBJECT_TYPE_SYMLINK] = object_process_symlink,
+};
+
+static int object_process(struct object *object,
+			  const struct storage *storage) {
+	int (*process_callback)(struct object *, const struct storage *);
+
+	process_callback = object_process_callbacks[object->type];
+	if (!process_callback) {
+		return 0;
+	}
+
+	return (process_callback)(object, storage);
+}
+
+static int
+object_process_directory_entry(const struct storage *storage,
+			       struct object *parent_object,
+			       const struct yaffs_dirent *directory_entry) {
+	struct object *object;
+	int ret;
+
+	ret = object_create_from_directory_entry(storage, parent_object,
+						 directory_entry, &object);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return object_process(object, storage);
+}
+
+static int object_recursive_discover(struct object *object,
+				     const struct storage *storage) {
+	const char *parent_path = object_get_path(object);
+	struct yaffs_dirent *directory_entry;
+	yaffs_DIR *dir;
+	int ret = 0;
+
+	dir = yaffs_opendir_reldev((struct yaffs_dev *)storage, parent_path);
+	if (!dir) {
+		ret = util_get_yaffs_errno();
+		log_error(ret, "error opening directory '%s'", parent_path);
+		return ret;
+	}
+
+	while ((directory_entry = yaffs_readdir(dir))) {
+		ret = object_process_directory_entry(storage, object,
+						     directory_entry);
+		if (ret < 0) {
+			break;
+		}
+	}
+
+	yaffs_closedir(dir);
+
+	return ret;
+}
+
+static bool object_is_directory(const struct object *object) {
+	switch (object->type) {
+	case LIST_OBJECT_TYPE_ROOT:
+	case LIST_OBJECT_TYPE_DIRECTORY:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static int object_compare(const void *pointer1, const void *pointer2) {
+	const struct object *object1 = pointer1;
+	const struct object *object2 = pointer2;
+
+	return strcasecmp(object_get_path(object1), object_get_path(object2));
+}
+
+static void object_recursive_sort(struct object *object) {
+	struct object_directory *directory = &object->data.directory;
+
+	if (!object_is_directory(object)) {
+		return;
+	}
+
+	qsort(directory->children, directory->children_count,
+	      sizeof(directory->children[0]), object_compare);
+
+	for (unsigned int i = 0; i < directory->children_count; i++) {
+		object_recursive_sort(&directory->children[i]);
+	}
+}
+
+int object_recursive_prepare(struct object *object,
+			     const struct storage *storage) {
+	int ret;
+
+	ret = object_recursive_discover(object, storage);
+	if (ret < 0) {
+		return ret;
+	}
+
+	object_recursive_sort(object);
+
+	return 0;
+}
+
+static int object_call(const struct object *object,
+		       int (*callback)(const struct object *, void *),
+		       void *callback_data) {
+	if (object->type == LIST_OBJECT_TYPE_ROOT) {
+		return 0;
+	}
+
+	return callback(object, callback_data);
+}
+
+static int object_call_for_children(const struct object *object,
+				    int (*callback)(const struct object *,
+						    void *),
+				    void *callback_data) {
+	const struct object_directory *directory = &object->data.directory;
+	int ret;
+
+	if (!object_is_directory(object)) {
+		return 0;
+	}
+
+	for (unsigned int i = 0; i < directory->children_count; i++) {
+		ret = object_recursive_call(&directory->children[i], callback,
+					    callback_data);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+int object_recursive_call(const struct object *object,
+			  int (*callback)(const struct object *, void *),
+			  void *callback_data) {
+	int ret;
+
+	ret = object_call(object, callback, callback_data);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return object_call_for_children(object, callback, callback_data);
+}

--- a/src/object.h
+++ b/src/object.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+#include <stdbool.h>
+
+#include "storage.h"
+
+enum object_type {
+	LIST_OBJECT_TYPE_UNKNOWN,
+	LIST_OBJECT_TYPE_ROOT,
+	LIST_OBJECT_TYPE_FILE,
+	LIST_OBJECT_TYPE_DIRECTORY,
+	LIST_OBJECT_TYPE_SYMLINK,
+};
+
+struct object {
+	char path_array[32];
+	char *path_ptr;
+	enum object_type type;
+	unsigned int mode;
+	unsigned long long size;
+	unsigned long long mtime;
+	union {
+		struct object_file {
+			bool executable;
+		} file;
+		struct object_directory {
+			unsigned int children_allocated;
+			unsigned int children_count;
+			struct object *children;
+		} directory;
+		struct object_symlink {
+			char *target;
+			bool broken;
+		} symlink;
+	} data;
+};
+
+const char *object_get_path(const struct object *object);
+
+int object_recursive_instantiate(struct object **objectp);
+void object_recursive_destroy(struct object **objectp);
+
+int object_recursive_prepare(struct object *object,
+			     const struct storage *storage);
+int object_recursive_call(const struct object *object,
+			  int (*callback)(const struct object *, void *),
+			  void *callback_data);

--- a/src/options.h
+++ b/src/options.h
@@ -9,9 +9,9 @@
 #define USAGE_MSG                                                              \
 	"Usage: %s "                                                           \
 	"-d { /dev/mtdX | /path/to/yaffs.img } "                               \
-	"{ -r | -w } "                                                         \
-	"-i <src> "                                                            \
-	"-o <dst> "                                                            \
+	"{ -l | -r | -w } "                                                    \
+	"[ -i <src> ] "                                                        \
+	"[ -o <dst> ] "                                                        \
 	"[ -m <mode> ] "                                                       \
 	"[ -t ] "                                                              \
 	"[ -C <bytes> ] "                                                      \
@@ -25,9 +25,10 @@
 	"[ -v ] "                                                              \
 	"[ -h ] "                                                              \
 	"\n\n"                                                                 \
-	"    -d  path to the MTD character device (or Yaffs image) to use\n"   \
-	"    -r  read a file from the MTD into a local file\n"                 \
-	"    -w  write a local file to a file on the MTD\n"                    \
+	"    -d  path to the MTD character device or Yaffs image to use\n"     \
+	"    -l  list Yaffs file system contents\n"                            \
+	"    -r  read a file from the Yaffs file system into a local file\n"   \
+	"    -w  write a local file to a file on the Yaffs file system\n"      \
 	"    -i  path to the source file (use '-' to read from stdin)\n"       \
 	"    -o  path to the destination file (use '-' to write to stdout)\n"  \
 	"    -m  set destination file access permissions to <mode> (octal)\n"  \
@@ -46,6 +47,7 @@
 
 enum program_mode {
 	PROGRAM_MODE_UNSPECIFIED,
+	PROGRAM_MODE_LIST,
 	PROGRAM_MODE_READ,
 	PROGRAM_MODE_WRITE,
 };
@@ -73,6 +75,7 @@ struct opts {
 	bool disable_checkpoints;
 	bool disable_summaries;
 	enum byte_order byte_order;
+	const char *output_format;
 };
 
 void options_parse_env(void);

--- a/src/printer.c
+++ b/src/printer.c
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "log.h"
+#include "options.h"
+#include "printer.h"
+#include "printer_driver.h"
+#include "printer_driver_text.h"
+#include "util.h"
+
+struct printer {
+	const struct printer_ops *ops;
+	void *driver_data;
+	void (*destroy_callback)(void **driver_datap);
+};
+
+static const struct printer_driver *printer_drivers[] = {
+	&printer_driver_text,
+	NULL,
+};
+
+static int printer_driver_parse(const struct opts *opts, char *driver_name,
+				size_t driver_name_size, char *driver_options,
+				size_t driver_options_size) {
+	const char *string = opts->output_format;
+	int ret;
+
+	ret = util_get_tokens(&string, ":", 2, driver_name, driver_name_size,
+			      driver_options, driver_options_size);
+	switch (ret) {
+	case 0:
+	case -EINTR:
+		return 0;
+	default:
+		log_error(ret, "failed to parse output format '%s'",
+			  opts->output_format);
+		return ret;
+	}
+}
+
+static int printer_driver_match(const char *driver_name,
+				const struct printer_driver **driverp) {
+	for (int i = 0; printer_drivers[i] != NULL; i++) {
+		const struct printer_driver *driver = printer_drivers[i];
+
+		if (!strcmp(driver->name, driver_name)) {
+			*driverp = driver;
+			return 0;
+		}
+	}
+
+	log("unknown output format '%s'", driver_name);
+
+	return -EINVAL;
+}
+
+static int printer_driver_instantiate(const struct printer_driver *driver,
+				      const char *driver_options,
+				      void **driver_datap) {
+	if (!driver->instantiate) {
+		*driver_datap = NULL;
+		return 0;
+	}
+
+	return driver->instantiate(driver_options, driver_datap);
+}
+
+static int printer_instantiate_with_options(const struct printer_driver *driver,
+					    const char *driver_options,
+					    struct printer **printerp) {
+	struct printer *printer;
+	void *driver_data;
+	int ret;
+
+	printer = calloc(1, sizeof(*printer));
+	if (!printer) {
+		return -ENOMEM;
+	}
+
+	ret = printer_driver_instantiate(driver, driver_options, &driver_data);
+	if (ret < 0) {
+		free(printer);
+		return ret;
+	}
+
+	*printer = (struct printer){
+		.ops = driver->ops,
+		.driver_data = driver_data,
+		.destroy_callback = driver->destroy,
+	};
+
+	*printerp = printer;
+
+	return 0;
+}
+
+int printer_instantiate(const struct opts *opts, struct printer **printerp) {
+	const struct printer_driver *driver;
+	char driver_name[16] = {0};
+	char driver_options[48] = {0};
+	int ret;
+
+	ret = printer_driver_parse(opts, driver_name, sizeof(driver_name),
+				   driver_options, sizeof(driver_options));
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = printer_driver_match(driver_name, &driver);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return printer_instantiate_with_options(driver, driver_options,
+						printerp);
+}
+
+void printer_destroy(struct printer **printerp) {
+	struct printer *printer = *printerp;
+
+	*printerp = NULL;
+
+	if (printer->destroy_callback) {
+		printer->destroy_callback(&printer->driver_data);
+	}
+
+	free(printer);
+}
+
+int printer_print_object(const struct object *object, void *data) {
+	const struct printer *printer = data;
+
+	return printer->ops->print_object(object, printer->driver_data);
+}

--- a/src/printer.h
+++ b/src/printer.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+#include "object.h"
+#include "options.h"
+
+struct printer;
+
+int printer_instantiate(const struct opts *opts, struct printer **printerp);
+void printer_destroy(struct printer **printerp);
+
+int printer_print_object(const struct object *object, void *data);

--- a/src/printer_driver.h
+++ b/src/printer_driver.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+#include "object.h"
+
+struct printer_ops {
+	int (*print_object)(const struct object *object, void *data);
+};
+
+struct printer_driver {
+	const char *name;
+	int (*instantiate)(const char *options, void **driver_datap);
+	void (*destroy)(void **driver_datap);
+	const struct printer_ops *ops;
+};

--- a/src/printer_driver_text.c
+++ b/src/printer_driver_text.c
@@ -1,0 +1,301 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "log.h"
+#include "object.h"
+#include "printer_driver.h"
+#include "printer_driver_text.h"
+#include "util.h"
+
+#define LS_COLORS_MAX_PATTERN_LENGTH 32
+#define LS_COLORS_MAX_COLOR_CODE_LENGTH 32
+
+struct printer_text_data_color {
+	const char *mnemonic;
+	const char *code;
+	char code_array[LS_COLORS_MAX_COLOR_CODE_LENGTH];
+};
+
+struct printer_text_data {
+	struct printer_text_data_colors {
+		struct printer_text_data_color file;
+		struct printer_text_data_color executable;
+		struct printer_text_data_color directory;
+		struct printer_text_data_color symlink;
+		struct printer_text_data_color symlink_broken;
+		bool enable;
+	} colors;
+};
+
+static void printer_text_colors_init(struct printer_text_data *text_data) {
+	text_data->colors = (struct printer_text_data_colors){
+		.file = {.mnemonic = "fi"},
+		.executable = {.mnemonic = "ex", .code = "1;32"},
+		.directory = {.mnemonic = "di", .code = "1;34"},
+		.symlink = {.mnemonic = "ln", .code = "1;36"},
+		.symlink_broken = {.mnemonic = "mi", .code = "1;31"},
+		.enable = true,
+
+	};
+}
+
+static void printer_text_LS_COLORS_find(const char *env_colors,
+					struct printer_text_data_color *color) {
+	const char *string = env_colors;
+	char pattern[LS_COLORS_MAX_PATTERN_LENGTH];
+	char color_code[LS_COLORS_MAX_COLOR_CODE_LENGTH];
+
+	while (!util_get_tokens(&string, "=:", 2, pattern, sizeof(pattern),
+				color_code, sizeof(color_code))) {
+		if (!strcmp(pattern, color->mnemonic)) {
+			(void)snprintf(color->code_array,
+				       sizeof(color->code_array), "%s",
+				       color_code);
+			color->code = color->code_array;
+			return;
+		}
+	}
+}
+
+static void printer_text_LS_COLORS_parse(struct printer_text_data *text_data) {
+	struct printer_text_data_colors *colors = &text_data->colors;
+	char *env_colors;
+
+	env_colors = getenv("LS_COLORS");
+	if (!env_colors) {
+		return;
+	}
+
+	printer_text_LS_COLORS_find(env_colors, &colors->file);
+	printer_text_LS_COLORS_find(env_colors, &colors->executable);
+	printer_text_LS_COLORS_find(env_colors, &colors->directory);
+	printer_text_LS_COLORS_find(env_colors, &colors->symlink);
+	printer_text_LS_COLORS_find(env_colors, &colors->symlink_broken);
+}
+
+static void printer_text_colors_setup(struct printer_text_data *text_data) {
+	printer_text_colors_init(text_data);
+	printer_text_LS_COLORS_parse(text_data);
+}
+
+static int
+printer_text_process_option_color(const char *value,
+				  struct printer_text_data *text_data) {
+	unsigned int value_number;
+	int ret;
+
+	ret = util_parse_number(value, 10, &value_number);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (value_number == 1) {
+		printer_text_colors_setup(text_data);
+	}
+
+	return 0;
+}
+
+static int printer_text_process_option(const char *name, const char *value,
+				       struct printer_text_data *text_data) {
+	if (!strcmp(name, "color")) {
+		return printer_text_process_option_color(value, text_data);
+	}
+
+	log("unknown option '%s'", name);
+
+	return -EINVAL;
+}
+
+static int printer_text_parse_option(const char **optionsp,
+				     struct printer_text_data *text_data,
+				     bool *donep) {
+	char name[16];
+	char value[2];
+	int ret;
+
+	ret = util_get_tokens(optionsp, "=,", 2, name, sizeof(name), value,
+			      sizeof(value));
+	switch (ret) {
+	case 0:
+		ret = printer_text_process_option(name, value, text_data);
+		*donep = (ret < 0);
+		return ret;
+	case -EPIPE:
+		*donep = true;
+		return 0;
+	default:
+		log_error(ret, "error parsing options near '%s'", *optionsp);
+		*donep = true;
+		return ret;
+	}
+}
+
+static int printer_text_parse_options(const char *options,
+				      struct printer_text_data *text_data) {
+	const char *string = options;
+	bool done;
+	int ret;
+
+	do {
+		ret = printer_text_parse_option(&string, text_data, &done);
+	} while (!done);
+
+	return ret;
+}
+
+static int printer_text_instantiate(const char *options, void **driver_datap) {
+	struct printer_text_data *text_data;
+	int ret;
+
+	text_data = calloc(1, sizeof(*text_data));
+	if (!text_data) {
+		return -ENOMEM;
+	}
+
+	ret = printer_text_parse_options(options, text_data);
+	if (ret < 0) {
+		free(text_data);
+		return ret;
+	}
+
+	*driver_datap = text_data;
+
+	return 0;
+}
+
+static void printer_text_destroy(void **driver_datap) {
+	struct printer_text_data *text_data = *driver_datap;
+
+	*driver_datap = NULL;
+
+	free(text_data);
+}
+
+static char printer_text_get_type_char(const struct object *object) {
+	switch (object->type) {
+	case LIST_OBJECT_TYPE_DIRECTORY:
+		return 'd';
+	case LIST_OBJECT_TYPE_SYMLINK:
+		return 'l';
+	default:
+		return '-';
+	}
+}
+
+static void printer_text_print_mode(const struct object *object) {
+	printf("%c%c%c%c%c%c%c%c%c%c", printer_text_get_type_char(object),
+	       (object->mode & S_IRUSR) ? 'r' : '-',
+	       (object->mode & S_IWUSR) ? 'w' : '-',
+	       (object->mode & S_IXUSR) ? 'x' : '-',
+	       (object->mode & S_IRGRP) ? 'r' : '-',
+	       (object->mode & S_IWGRP) ? 'w' : '-',
+	       (object->mode & S_IXGRP) ? 'x' : '-',
+	       (object->mode & S_IROTH) ? 'r' : '-',
+	       (object->mode & S_IWOTH) ? 'w' : '-',
+	       (object->mode & S_IXOTH) ? 'x' : '-');
+}
+
+static void printer_text_print_size(const struct object *object) {
+	printf("%8llu", object->size);
+}
+
+static void printer_text_print_mtime(const struct object *object) {
+	struct tm *mtime = gmtime((const time_t *)&object->mtime);
+	char mtime_formatted[32];
+
+	(void)strftime(mtime_formatted, sizeof(mtime_formatted),
+		       "%Y-%m-%d %H:%M:%S", mtime);
+
+	printf("%s", mtime_formatted);
+}
+
+static const char *
+printer_text_get_object_color(const struct object *object,
+			      const struct printer_text_data *text_data) {
+	const struct printer_text_data_colors *colors = &text_data->colors;
+
+	switch (object->type) {
+	case LIST_OBJECT_TYPE_FILE:
+		if (object->data.file.executable && colors->executable.code) {
+			return colors->executable.code;
+		}
+		return colors->file.code ?: "0";
+	case LIST_OBJECT_TYPE_DIRECTORY:
+		return colors->directory.code ?: "0";
+	case LIST_OBJECT_TYPE_SYMLINK:
+		if (object->data.symlink.broken
+		    && colors->symlink_broken.code) {
+			return colors->symlink_broken.code;
+		}
+		return text_data->colors.symlink.code ?: "0";
+	default:
+		return "0";
+	}
+}
+
+static void printer_text_print_colored_string(const char *string,
+					      const char *color) {
+	if (color) {
+		printf("\e[%sm", color);
+	}
+
+	printf("%s", string);
+
+	if (color) {
+		printf("\e[0m");
+	}
+}
+
+static void printer_text_print_path(const struct object *object,
+				    const struct printer_text_data *text_data) {
+	const char *color = NULL;
+
+	if (text_data->colors.enable) {
+		color = printer_text_get_object_color(object, text_data);
+	}
+
+	printer_text_print_colored_string(object_get_path(object), color);
+
+	if (object->type == LIST_OBJECT_TYPE_SYMLINK) {
+		printf(" -> ");
+		printer_text_print_colored_string(object->data.symlink.target,
+						  color);
+	}
+}
+
+static int printer_text_print_object(const struct object *object, void *data) {
+	const struct printer_text_data *text_data = data;
+
+	printer_text_print_mode(object);
+	printf("  ");
+	printer_text_print_size(object);
+	printf("  ");
+	printer_text_print_mtime(object);
+	printf("  ");
+	printer_text_print_path(object, text_data);
+	printf("\n");
+
+	return 0;
+}
+
+static const struct printer_ops printer_text_ops = {
+	.print_object = printer_text_print_object,
+};
+
+const struct printer_driver printer_driver_text = {
+	.name = "text",
+	.instantiate = printer_text_instantiate,
+	.destroy = printer_text_destroy,
+	.ops = &printer_text_ops,
+};

--- a/src/printer_driver_text.h
+++ b/src/printer_driver_text.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+#include "printer_driver.h"
+
+extern const struct printer_driver printer_driver_text;

--- a/src/storage.c
+++ b/src/storage.c
@@ -50,7 +50,7 @@ static int storage_open(struct storage *storage) {
 	int flags;
 	int ret;
 
-	flags = (storage->opts->mode == PROGRAM_MODE_READ ? O_RDONLY : O_RDWR);
+	flags = (storage->opts->mode == PROGRAM_MODE_WRITE ? O_RDWR : O_RDONLY);
 	storage->fd = open(storage->path, flags);
 	if (storage->fd < 0) {
 		ret = util_get_errno();

--- a/src/tree.c
+++ b/src/tree.c
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <yaffsfs.h>
+
+#include "log.h"
+#include "object.h"
+#include "options.h"
+#include "printer.h"
+#include "storage.h"
+#include "tree.h"
+#include "util.h"
+
+static int tree_mount(const struct opts *opts, struct storage **storagep) {
+	struct storage *storage;
+	int ret;
+
+	ret = storage_instantiate(opts, &storage);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = yaffs_mount_reldev((struct yaffs_dev *)storage);
+	if (ret < 0) {
+		ret = util_get_yaffs_errno();
+		log_error(ret, "unable to mount Yaffs filesystem");
+		storage_destroy(&storage);
+		return ret;
+	}
+
+	*storagep = storage;
+
+	return 0;
+}
+
+static void tree_unmount(struct storage **storagep) {
+	struct storage *storage = *storagep;
+	int ret;
+
+	ret = yaffs_unmount_reldev((struct yaffs_dev *)storage);
+	if (ret < 0) {
+		ret = util_get_yaffs_errno();
+		log_error(ret, "error unmounting Yaffs filesystem");
+	}
+
+	storage_destroy(storagep);
+}
+
+static int tree_print_with_printer(const struct storage *storage,
+				   const struct printer *printer) {
+	struct object *tree_root;
+	int ret;
+
+	ret = object_recursive_instantiate(&tree_root);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = object_recursive_prepare(tree_root, storage);
+	if (ret < 0) {
+		object_recursive_destroy(&tree_root);
+		return ret;
+	}
+
+	ret = object_recursive_call(tree_root, printer_print_object,
+				    (void *)printer);
+
+	object_recursive_destroy(&tree_root);
+
+	return ret;
+}
+
+static int tree_print(const struct opts *opts, const struct storage *storage) {
+	struct printer *printer;
+	int ret;
+
+	ret = printer_instantiate(opts, &printer);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = tree_print_with_printer(storage, printer);
+
+	printer_destroy(&printer);
+
+	return ret;
+}
+
+int tree_print_based_on_opts(const struct opts *opts) {
+	struct storage *storage;
+	int ret;
+
+	ret = tree_mount(opts, &storage);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = tree_print(opts, storage);
+
+	tree_unmount(&storage);
+
+	return ret;
+}

--- a/src/tree.h
+++ b/src/tree.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Michał Kępień <yafut@kempniu.pl>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+#include "options.h"
+
+int tree_print_based_on_opts(const struct opts *opts);

--- a/src/util.h
+++ b/src/util.h
@@ -7,22 +7,26 @@
 #if defined(__clang_analyzer__) || defined(__gcc_analyzer__)
 
 /*
- * Make util_get_errno() always return -1 when Clang Static Analyzer or GCC
- * Static Analyzer is in use.  This silences its warnings triggered by 'errno'
- * possibly being zero on errors, which should never be the case.  However...
+ * Make functions retrieving error codes always return -1 when Clang Static
+ * Analyzer or GCC Static Analyzer is in use.  This silences the warnings
+ * triggered by these codes possibly being zero on errors, which should never
+ * be the case.  However...
  */
 #define util_get_errno() -1
+#define util_get_yaffs_errno() -1
 
 #else /* defined(__clang_analyzer__) || defined(__gcc_analyzer__) */
 
 /*
  * ...rather than assume things, when Clang Static Analyzer or GCC Static
- * Analyzer is _not_ in use, instead of accessing 'errno' directly, use a
- * helper function that actually checks whether 'errno' lives up to its promise
- * at run time (and call abort() if it does not).
+ * Analyzer is _not_ in use, employ helper functions to actually check whether
+ * the error codes live up to their promises at run time (and call abort() if
+ * they do not).
  */
 #define util_get_errno() util_get_errno_location(__FILE__, __LINE__, __func__)
 int util_get_errno_location(const char *file, int line, const char *func);
+
+#define util_get_yaffs_errno() yaffsfs_GetLastError()
 
 #endif /* defined(__clang_analyzer__) || defined(__gcc_analyzer__) */
 

--- a/src/util.h
+++ b/src/util.h
@@ -32,3 +32,6 @@ int util_get_errno_location(const char *file, int line, const char *func);
 
 char *util_get_error(int err);
 int util_parse_number(const char *string, int base, unsigned int *result);
+
+int util_get_tokens(const char **stringp, const char *delimiters,
+		    unsigned int max_tokens, ...);


### PR DESCRIPTION
Add a new mode of operation, -l, for listing Yaffs file system contents.  This is useful for sanity-checking the Yaffs layout parameters used.  Emit colored output when standard output is a terminal, taking the LS_COLORS environment variable into account.

Fixes #17