### PR TITLE
Update operating system versions used by workflows

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -18,12 +18,12 @@ jobs:
   build:
     strategy:
       matrix:
-        image: ['alpine:3.19', 'debian:12', 'fedora:40', 'redhat/ubi9:latest', 'ubuntu:24.04']
+        image: ['alpine:3.21', 'debian:12', 'fedora:42', 'redhat/ubi9:latest', 'ubuntu:24.04']
         compiler: ['clang', 'gcc']
         include:
-          - image: 'macos-14'
+          - image: 'macos-15'
             compiler: 'clang'
-    runs-on: ${{ !startsWith(matrix.image, 'macos') && 'ubuntu-22.04' || matrix.image }}
+    runs-on: ${{ !startsWith(matrix.image, 'macos') && 'ubuntu-24.04' || matrix.image }}
     container: ${{ !startsWith(matrix.image, 'macos') && matrix.image || null }}
     name: Build (${{ matrix.image }}, ${{ matrix.compiler }})
     steps:
@@ -82,7 +82,7 @@ jobs:
           GCC_STATIC_ANALYZER: ${{ (startsWith(matrix.image, 'ubuntu') && matrix.compiler == 'gcc') && 'CFLAGS="-fanalyzer -D__gcc_analyzer__" ' || '' }}
         run: ${{ env.GCC_STATIC_ANALYZER }}${{ env.CLANG_STATIC_ANALYZER }}cmake ${{ env.CMAKE_ARGS_STANDARD }}${{ env.CMAKE_ARGS_EXTRA }} -B build && ${{ env.CLANG_STATIC_ANALYZER }}cmake --build build
   clang-format:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Code style
     steps:
       - name: Check out repository

--- a/.github/workflows/licensing.yml
+++ b/.github/workflows/licensing.yml
@@ -7,7 +7,7 @@ on: pull_request
 
 jobs:
   reuse:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Licensing
     steps:
       - name: Check out repository


### PR DESCRIPTION
Update the images used by the "build" workflow to ensure that Yafut compiles on the latest available version of each tested operating system.

Update to Ubuntu 24.04 as the default host for all workflows.